### PR TITLE
Simplify the difficulty settings

### DIFF
--- a/code/g.py
+++ b/code/g.py
@@ -1176,11 +1176,13 @@ def new_game(difficulty):
         pl.interest_rate = 5
         pl.labor_bonus = 2500
         pl.grace_multiplier = 400
+        pl.grace_period_cpu = -1
         discover_bonus = 7000
     elif difficulty < 5:
         pl.interest_rate = 3
         pl.labor_bonus = 5000
         pl.grace_multiplier = 300
+        pl.grace_period_cpu = 1000000
         discover_bonus = 9000
     elif difficulty == 5:
         pass
@@ -1188,18 +1190,22 @@ def new_game(difficulty):
     #    pl.interest_rate = 1
     #    pl.labor_bonus = 10000
     #    pl.grace_multiplier = 200
+    #    pl.grace_period_cpu = 20000
     #    discover_bonus = 10000
     elif difficulty < 8:
         pl.labor_bonus = 11000
         pl.grace_multiplier = 180
+        pl.grace_period_cpu = 7500
         discover_bonus = 11000
     elif difficulty <= 50:
         pl.labor_bonus = 15000
         pl.grace_multiplier = 150
+        pl.grace_period_cpu = 2500
         discover_bonus = 13000
     else:
         pl.labor_bonus = 20000
         pl.grace_multiplier = 100
+        pl.grace_period_cpu = 100
         discover_bonus = 15000
 
     if difficulty != 5:

--- a/code/g.py
+++ b/code/g.py
@@ -1189,26 +1189,18 @@ def new_game(difficulty):
     #    pl.labor_bonus = 10000
     #    pl.grace_multiplier = 200
     #    discover_bonus = 10000
-    #    for group in pl.groups.values():
-    #        group.discover_suspicion = 1000
     elif difficulty < 8:
         pl.labor_bonus = 11000
         pl.grace_multiplier = 180
         discover_bonus = 11000
-        for group in pl.groups.values():
-            group.discover_suspicion = 1500
     elif difficulty <= 50:
         pl.labor_bonus = 15000
         pl.grace_multiplier = 150
         discover_bonus = 13000
-        for group in pl.groups.values():
-            group.discover_suspicion = 2000
     else:
         pl.labor_bonus = 20000
         pl.grace_multiplier = 100
         discover_bonus = 15000
-        for group in pl.groups.values():
-            group.discover_suspicion = 2000
 
     if difficulty != 5:
         for group in pl.groups.values():


### PR DESCRIPTION
Change the difficulty settings.

* (**MERGED**) Currently player start at high difficulty with suspicions. As suspicion decay during grace period, it doesn't affect the game, suspicions will be zero when the player end grace period.
**Change =>** Remove starting suspicion at high difficulty 


* Grace period is limited at high difficulty by adding restriction in order to avoid breaking the game before it start. These restrictions limit the cpu a player can accumulate without ending the grace period. So it is strictly equivalent to a limit to the cpu used by the player in cash or in research.
**Change =>** Replace all restrictions with a simple limit of used cpu. The grace period end when the player reach the maximum of cpu accumulated each day allowed by the difficulty. 
**Rationale =>** It let more freedom to the player. The player can create a lot of base and finish the grace period quickly or can just start the old way. Simplify the grace period conditions and penalize less the player who don't know them. The eleven base will not end the grace period immediately but just a little faster.