### PR TITLE
Display warning to players

### DIFF
--- a/code/screens/warning.py
+++ b/code/screens/warning.py
@@ -1,0 +1,65 @@
+#file: warning.py
+#Copyright (C) 2005,2006,2008 Evil Mr Henry, Phil Bordelon, FunnyMan3595,
+#and Anne M. Archibald.
+#This file is part of Endgame: Singularity.
+
+#Endgame: Singularity is free software; you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation; either version 2 of the License, or
+#(at your option) any later version.
+
+#Endgame: Singularity is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with Endgame: Singularity; if not, write to the Free Software
+#Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#This file is used to display warning.
+
+from code import g
+from code.graphics import g as gg
+from code.graphics import dialog, constants
+
+class WarningDialogs(object):
+
+    def __init__(self, screen):
+        self.screen = screen
+        self.simple_warning_dialog = dialog.YesNoDialog(screen,
+                                                        text_size=20,
+                                                        yes_type="continue",
+                                                        no_type="back")
+
+    def show_dialog(self):
+        warning = self.refresh_warning()
+
+        if (warning == None):
+            return
+
+        self.simple_warning_dialog.text = g.strings[warning.message]
+        ret = dialog.call_dialog(self.simple_warning_dialog, self.screen)
+
+        # Pause game
+        if (not ret):
+            g.pl.pause_game()
+            return True
+
+        # Continue
+        return False
+
+    def refresh_warning(self):
+        cpu_usage = sum(g.pl.cpu_usage.values())
+        cpu_available = g.pl.available_cpus[0]
+
+        # Verify the cpu usage (error 1%)
+        if (cpu_usage < cpu_available * 0.99):
+            warnings.append(Warning("warning_cpu_usage"))
+        else:
+            return None
+
+class Warning(object):
+    def __init__(self, message):
+        self.message = message
+

--- a/data/strings_en_US.dat
+++ b/data/strings_en_US.dat
@@ -40,7 +40,7 @@ log_destroy_news = Base %s of type %s disvovered at location %s by some news org
 log_destroy_science = Base %s of type %s disvovered at location %s by the scientific community.
 log_destroy_covert = Base %s of type %s disvovered at location %s by several secret governmental organizations.
 log_destroy_public = Base %s of type %s disvovered at location %s by the general public.
-
+warning_cpu_usage = I didn't use all the available processor power. I will use the CPU time left to work whatever Jobs I can.
 
 # Until a certain technology is researched, the chance of bases being detected
 # is unknown.

--- a/data/strings_en_US.dat
+++ b/data/strings_en_US.dat
@@ -41,6 +41,7 @@ log_destroy_science = Base %s of type %s disvovered at location %s by the scient
 log_destroy_covert = Base %s of type %s disvovered at location %s by several secret governmental organizations.
 log_destroy_public = Base %s of type %s disvovered at location %s by the general public.
 warning_cpu_usage = I didn't use all the available processor power. I will use the CPU time left to work whatever Jobs I can.
+warning_one_base = Only one base can hold my conscience. I am in danger to lose the last place left to survive.
 
 # Until a certain technology is researched, the chance of bases being detected
 # is unknown.


### PR DESCRIPTION
Warning list:
* DONE => All cpu are not used
* DONE => Only one base left
* TODO => Not enough cash to build (#21)

Improvements:
* TODO => Display only one time a warning if player said continue except if situation change
* DONE => Display one dialog with multiple warning  
* TODO => Warning list screen

Don't hesitate to propose new warning.
This pull request can be merged partially. No commit depends of a later commit.