### PR TITLE
Skip an expected theme directory if it does not exist

### DIFF
--- a/code/g.py
+++ b/code/g.py
@@ -895,6 +895,8 @@ def load_themes():
     themes_dirs = dirs.get_read_dirs("themes")
 
     for themes_dir in themes_dirs:
+        if not os.path.isdir(themes_dir):
+            continue
         themes_list = [name for name in os.listdir(themes_dir)
                             if os.path.isdir(os.path.join(themes_dir, name))]
 


### PR DESCRIPTION
When running after fixing #72, I then got the following error:
```

/home/rcriii/workspace/singularity/singularity.py
Traceback (most recent call last):
  File "/home/rcriii/workspace/singularity/singularity.py", line 23, in <module>
    import code.singularity
  File "/home/rcriii/workspace/singularity/code/singularity.py", line 260, in <module>
    g.load_themes()
  File "/home/rcriii/workspace/singularity/code/g.py", line 900, in load_themes
    themes_list = [name for name in os.listdir(themes_dir)
OSError: [Errno 2] No such file or directory: '/home/rcriii/.local/share/singularity/themes'
```

This fixes that error by ignoring '/home/rcriii/.local/share/singularity/themes' if it does not exist, the program then grabs the default themes from the source directory.