### PR TITLE
Add suspicion multiplier and reduce discover multiplier

### DIFF
--- a/code/difficulty.py
+++ b/code/difficulty.py
@@ -30,6 +30,7 @@ columns = (
     'starting_interest_rate',
     'labor_multiplier',
     'discover_multiplier',
+    'suspicion_multiplier',
     'base_grace_multiplier',
     'story_grace_difficulty',
 )

--- a/code/g.py
+++ b/code/g.py
@@ -1154,6 +1154,7 @@ def new_game(difficulty_name):
 
     for group in pl.groups.values():
         group.discover_bonus = diff.discover_multiplier
+        group.suspicion_bonus = diff.suspicion_multiplier
 
     # Reset all "mutable" game data
     load_locations()

--- a/code/player.py
+++ b/code/player.py
@@ -30,13 +30,17 @@ from buyable import cash, cpu
 
 group_list = ("news", "science", "covert", "public")
 class Group(object):
-    discover_suspicion = 1000
+    base_discover_suspicion=1000
     def __init__(self, name, suspicion = 0, suspicion_decay = 100,
-                 discover_bonus = 10000):
+                 discover_bonus = 10000, suspicion_bonus = 10000):
         self.name = name
         self.suspicion = suspicion
         self.suspicion_decay = suspicion_decay
         self.discover_bonus = discover_bonus
+
+    @property
+    def discover_suspicion(self):
+        return (self.base_discover_suspicion * self.suspicion_bonus) // 10000
 
     def decay_rate(self):
         # Suspicion reduction is now quadratic.  You get a certain percentage

--- a/data/difficulties.dat
+++ b/data/difficulties.dat
@@ -2,7 +2,8 @@
 starting_cash = 5000
 starting_interest_rate = 5
 labor_multiplier = 2500
-discover_multiplier = 7000
+discover_multiplier = 8750
+suspicion_multiplier = 8000
 base_grace_multiplier = 40000
 story_grace_difficulty = 1
 tech_list = Socioanalytics | Advanced Socioanalytics
@@ -11,7 +12,8 @@ tech_list = Socioanalytics | Advanced Socioanalytics
 starting_cash = 1600
 starting_interest_rate = 3
 labor_multiplier = 5000
-discover_multiplier = 9000
+discover_multiplier = 9500
+suspicion_multiplier = 9500
 base_grace_multiplier = 30000
 story_grace_difficulty = 3
 tech_list = Socioanalytics
@@ -21,6 +23,7 @@ starting_cash = 1000
 starting_interest_rate = 1
 labor_multiplier = 10000
 discover_multiplier = 10000
+suspicion_multiplier = 10000
 base_grace_multiplier = 20000
 story_grace_difficulty = 5
 
@@ -28,7 +31,8 @@ story_grace_difficulty = 5
 starting_cash = 700
 starting_interest_rate = 1
 labor_multiplier = 11000
-discover_multiplier = 11000
+discover_multiplier = 10500
+suspicion_multiplier = 10500
 base_grace_multiplier = 18000
 story_grace_difficulty = 7
 
@@ -36,14 +40,16 @@ story_grace_difficulty = 7
 starting_cash = 500
 starting_interest_rate = 1
 labor_multiplier = 15000
-discover_multiplier = 13000
-base_grace_multiplier = 15000
+discover_multiplier = 11250
+suspicion_multiplier = 11500
+base_grace_multiplier = 12000
 story_grace_difficulty = 10
 
 [impossible]
 starting_cash = 0
 starting_interest_rate = 1
 labor_multiplier = 20000
-discover_multiplier = 15000
+discover_multiplier = 12000
+suspicion_multiplier = 12500
 base_grace_multiplier = 10000
 story_grace_difficulty = 100


### PR DESCRIPTION
It shouldn't change the chance per day to lost, but reduce cost of discovering (less discover = less base to rebuilt). Since discover cost is mostly relevant at the beginning, it is not a real problem, but something good (since now the beginning is hard but the end is easier).

Basically, Expected value (lost) = discover_chance * suspicion_value
So, we rise suspicion_value, we can reduce discover_chance. Before suspicion_value was constant.

Very Easy = 7000 * 10000 = 8750 * 8000              
Easy = 9000 * 10000 =~ 9500 * 9500                   
Hard = 11000 * 10000 =~ 10500 *10500         
Very-Hard = 13000 * 10000 =~ 11250 * 11500     
Impossible = 15000 * 10000 = 12000 * 12500
(not all expected value are exactly equals)
