### PR TITLE
Add option to disable unused CPU warnings

### DIFF
--- a/code/g.py
+++ b/code/g.py
@@ -60,6 +60,9 @@ mixerinit = False
 # Enables day/night display.
 daynight = True
 
+# Warn about unused CPUs
+cpu_warning = True
+
 #Gives debug info at various points.
 debug = 0
 

--- a/code/screens/options.py
+++ b/code/screens/options.py
@@ -89,6 +89,7 @@ class OptionsScreen(dialog.FocusDialog, dialog.YesNoDialog):
             fullscreen      = gg.fullscreen,
             grab            = pygame.event.get_grab(),
             daynight        = g.daynight,
+            cpu_warning     = g.cpu_warning,
             resolution      = gg.screen_size,
             language        = i18n.language,
             sound           = not g.nosound,
@@ -261,10 +262,22 @@ class GeneralPane(widget.Widget):
                                   update_func=theme.set_theme,
                                   list_pos=theme.get_theme_pos())
 
+        # Sixth row
+        self.cpu_warning_label = button.HotkeyText(self, (.01, .60), (.20, .05),
+                                                autohotkey=True,
+                                                background_color="clear")
+        self.cpu_warning_toggle = OptionButton(self, (.23, .60), (.07, .05),
+                                        text_shrink_factor=.75,
+                                        force_underline=-1,
+                                        function=self.set_cpu_warning,
+                                        args=(button.TOGGLE_VALUE,))
+        self.cpu_warning_label.hotkey_target = self.cpu_warning_toggle
+
     def rebuild(self):
         self.fullscreen_label.text          = _("&Fullscreen:")
         self.grab_label.text                = _("&Mouse grab:")
         self.daynight_label.text            = _("Da&y/night display:")
+        self.cpu_warning_label.text         = _("Unused &CPU Warnings:")
         self.language_label.text            = _("Language:")
         self.resolution_label.text          = _("Resolution:")
         self.resolution_custom.text         = _("&CUSTOM:")
@@ -292,6 +305,9 @@ class GeneralPane(widget.Widget):
 
         self.set_daynight(options['daynight'])
         self.daynight_toggle.set_active(options['daynight'])
+
+        self.set_cpu_warning(options['cpu_warning'])
+        self.cpu_warning_toggle.set_active(options['cpu_warning'])
 
         custom = True
         for res_button in self.resolution_group:
@@ -354,6 +370,13 @@ class GeneralPane(widget.Widget):
         else:
             self.daynight_toggle.text = _("NO")
         g.daynight = value
+
+    def set_cpu_warning(self, value):
+        if value:
+            self.cpu_warning_toggle.text = _("YES")
+        else:
+            self.cpu_warning_toggle.text = _("NO")
+        g.cpu_warning = value
 
     def set_resolution(self, value):
         if gg.screen_size != value:
@@ -523,6 +546,7 @@ def save_options():
     prefs.set("Preferences", "nosound",      str(bool(g.nosound)))
     prefs.set("Preferences", "grab",         str(bool(pygame.event.get_grab())))
     prefs.set("Preferences", "daynight",     str(bool(g.daynight)))
+    prefs.set("Preferences", "cpu_warning",  str(bool(g.cpu_warning)))
     prefs.set("Preferences", "xres",         str(int(gg.screen_size[0])))
     prefs.set("Preferences", "yres",         str(int(gg.screen_size[1])))
     prefs.set("Preferences", "soundbuf",     str(int(g.soundbuf)))

--- a/code/screens/warning.py
+++ b/code/screens/warning.py
@@ -53,12 +53,13 @@ class WarningDialogs(object):
     def refresh_warnings(self):
         warnings = []
 
-        cpu_usage = sum(g.pl.cpu_usage.values())
-        cpu_available = g.pl.available_cpus[0]
+        if g.cpu_warning:
+            cpu_usage = sum(g.pl.cpu_usage.values())
+            cpu_available = g.pl.available_cpus[0]
 
-        # Verify the cpu usage (error 1%)
-        if (cpu_usage < cpu_available * 0.99):
-            warnings.append(Warning("warning_cpu_usage"))
+            # Verify the cpu usage (error 1%)
+            if (cpu_usage < cpu_available * 0.99):
+                warnings.append(Warning("warning_cpu_usage"))
 
         # Verify I have two base build (or one base will be build next tick)
         # Base must have one cpu build (or one cpu will be build next tick)

--- a/code/singularity.py
+++ b/code/singularity.py
@@ -118,6 +118,11 @@ if save_loc is not None:
             sys.stderr.write("Invalid or missing 'daynight' setting in preferences.\n")
 
         try:
+            g.cpu_warning = prefs.getboolean("Preferences", "cpu_warning")
+        except:
+            sys.stderr.write("Invalid or missing 'cpu_warning' setting in preferences.\n")
+
+        try:
             desired_soundbuf = prefs.getint("Preferences", "soundbuf")
         except:
             sys.stderr.write("Invalid or missing 'soundbuf' setting in preferences.\n")
@@ -166,6 +171,10 @@ parser.add_option("--daynight", action="store_true", dest="daynight",
                   help="enable day/night display (default)")
 parser.add_option("--nodaynight", action="store_false", dest="daynight",
                   help="disable day/night display")
+parser.add_option("--cpu_warning", action="store_true", dest="cpu_warning",
+                  help="Warn about unused CPUs (default)")
+parser.add_option("--no-cpu_warning", action="store_false", dest="cpu_warning",
+                  help="Disable unused CPU warnings")
 parser.add_option("-l", "--lang", "--language", dest="language", type="choice",
                   choices=langs, metavar="LANG",
                   help="set the language to LANG (available languages: " +
@@ -241,6 +250,8 @@ if options.sound is not None:
     g.nosound = not options.sound
 if options.daynight is not None:
     g.daynight = options.daynight
+if options.cpu_warning is not None:
+    g.cpu_warning = options.cpu_warning
 if options.soundbuf is not None:
     g.soundbuf = options.soundbuf
 


### PR DESCRIPTION
I am a heavy user of CPU Pool task, which allocates unused CPUs to working jobs for money. I find that the frequent warnings about unused CPUs when they are actually being used for jobs really breaks the flow of the game.

The changes in this pull request add an option to disable those warnings.

I modelled the new option after `daynight`, so in particular it adds a new global setting in `code/g.py`.

It wasn't obvious what the best place would be to add the new option in the Options screen. I decided it would be best to create a new row under the existing options for two reasons:

1. There seems to be enough room there
2. Looking in the code, there are warnings when you are in danger of losing your last base. A sixth option row provides a place where the base warnings could be toggled as well, if that is implemented in future.