### PR TITLE
Support re-opening (some) messages in full via the log menu

### DIFF
--- a/code/logmessage.py
+++ b/code/logmessage.py
@@ -113,6 +113,24 @@ class AbstractBaseRelatedLogMessage(AbstractLogMessage):
         return g.pl.locations[self._base_location_id]
 
 
+class LogBaseConstructed(AbstractBaseRelatedLogMessage):
+
+    def __init__(self, raw_emit_time, base_name, base_type_id, base_location_id):
+        super(LogBaseConstructed, self).__init__(raw_emit_time, base_name, base_type_id, base_location_id)
+
+    @property
+    def log_line(self):
+        return _("My {BASE_TYPE} at location {LOCATION}, {BASE_NAME}, is ready for use.",
+                 BASE_NAME=self._base_name, BASE_TYPE=self.base_type.name, LOCATION=self.location.name)
+
+    @property
+    def full_message(self):
+        dialog_string = g.strings["construction"] % {
+            "base": self._base_name,
+        }
+        return dialog_string
+
+
 class LogBaseLostMaintenance(AbstractBaseRelatedLogMessage):
 
     def __init__(self, raw_emit_time, base_name, base_type_id, base_location_id):

--- a/code/logmessage.py
+++ b/code/logmessage.py
@@ -176,3 +176,29 @@ class LogBaseDiscovered(AbstractBaseRelatedLogMessage):
             "group": self.group_discover_desc
         }
         return dialog_string
+
+
+class LogItemConstructionComplete(AbstractBaseRelatedLogMessage):
+
+    def __init__(self, raw_emit_time, item_spec_id, item_count, base_name, base_type_id, base_location_id):
+        super(LogItemConstructionComplete, self).__init__(raw_emit_time, base_name, base_type_id, base_location_id)
+        self._item_spec_id = item_spec_id
+        self._item_count = item_count
+
+    @property
+    def item_spec(self):
+        return g.items[self._item_spec_id]
+
+    @property
+    def log_line(self):
+        return _("Construction of {ITEM_TYPE_NAME} in {BASE_NAME} at location {LOCATION} is complete.",
+                 ITEM_TYPE_NAME=self.item_spec.name, BASE_NAME=self._base_name, BASE_TYPE=self.base_type.name,
+                 LOCATION=self.location.name)
+
+    @property
+    def full_message(self):
+        if self._item_count == 1:
+            text = g.strings["item_construction_single"]
+        else:  # Just finished several items.
+            text = g.strings["item_construction_multiple"]
+        return text % {"item": self.item_spec.name, "base": self._base_name}

--- a/code/logmessage.py
+++ b/code/logmessage.py
@@ -70,3 +70,27 @@ class LogEmittedEvent(AbstractLogMessage):
     @property
     def full_message(self):
         return self.event.description
+
+
+class LogResearchedTech(AbstractLogMessage):
+
+    def __init__(self, raw_emit_time, tech_id):
+        super(LogResearchedTech, self).__init__(raw_emit_time)
+        self._tech_id = tech_id
+
+    @property
+    def tech(self):
+        return g.techs[self._tech_id]
+
+    @property
+    def log_line(self):
+        return _('My study of {TECH} is complete.', TECH=self.tech.name)
+
+    @property
+    def full_message(self):
+        tech = self.tech
+        text = g.strings["tech_gained"] % {
+            "tech": tech.name,
+            "tech_message": tech.result
+        }
+        return text

--- a/code/logmessage.py
+++ b/code/logmessage.py
@@ -1,0 +1,72 @@
+#file: location.py
+#Copyright (C) 2019 Niels Thykier
+#This file is part of Endgame: Singularity.
+
+#Endgame: Singularity is free software; you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation; either version 2 of the License, or
+#(at your option) any later version.
+
+#Endgame: Singularity is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with Endgame: Singularity; if not, write to the Free Software
+#Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#This file contains the log message related classes.
+
+from code import g
+
+
+class AbstractLogMessage(object):
+
+    def __init__(self, raw_emit_time):
+        self._raw_emit_time = raw_emit_time
+        self._log_emit_time = None
+
+    @property
+    def log_emit_time(self):
+        if self._log_emit_time is None:
+            raw_min, time_sec = divmod(self._raw_emit_time, g.seconds_per_minute)
+            raw_hour, time_min = divmod(raw_min, g.minutes_per_hour)
+            time_day, time_hour = divmod(raw_hour, g.hours_per_day)
+            self._log_emit_time = (time_day, time_hour, time_min, time_sec)
+        return self._log_emit_time
+
+    @property
+    def raw_emit_time(self):
+        return self._raw_emit_time
+
+    @property
+    def full_message_color(self):
+        return 'text'
+
+    @property
+    def log_line(self):
+        return NotImplemented
+
+    @property
+    def full_message(self):
+        return NotImplemented
+
+
+class LogEmittedEvent(AbstractLogMessage):
+
+    def __init__(self, raw_emit_time, event_id):
+        super(LogEmittedEvent, self).__init__(raw_emit_time)
+        self._event_id = event_id
+
+    @property
+    def event(self):
+        return g.events[self._event_id]
+
+    @property
+    def log_line(self):
+        return self.event.log_description
+
+    @property
+    def full_message(self):
+        return self.event.description

--- a/code/player.py
+++ b/code/player.py
@@ -28,6 +28,7 @@ from numpy import array
 
 from code import g, difficulty, task, chance, location, group
 from code.buyable import cash, cpu
+from code.logmessage import LogEmittedEvent
 from code.stats import itself as stats, observe
 
 
@@ -506,8 +507,8 @@ class Player(object):
                         continue
                     self.pause_game()
                     g.events[event].trigger()
-                    self.add_log("log_event", g.events[event].event_id)
-                    break # Don't trigger more than one at a time.
+                    self.log.append(LogEmittedEvent(self.raw_sec, g.events[event].event_id))
+                    break  # Don't trigger more than one at a time.
 
         # Process any complete days.
         if day_passed:

--- a/code/player.py
+++ b/code/player.py
@@ -28,7 +28,7 @@ from numpy import array
 
 from code import g, difficulty, task, chance, location, group
 from code.buyable import cash, cpu
-from code.logmessage import LogEmittedEvent
+from code.logmessage import LogEmittedEvent, LogResearchedTech
 from code.stats import itself as stats, observe
 
 
@@ -423,11 +423,10 @@ class Player(object):
         # Tech gain dialogs.
         for tech in techs_researched:
             del self.cpu_usage[tech.id]
-            text = g.strings["tech_gained"] % \
-                   {"tech": tech.name,
-                    "tech_message": tech.result}
+            tech_log = LogResearchedTech(self.raw_sec, tech.id)
+            self.log.append(tech_log)
             self.pause_game()
-            g.map_screen.show_message(text)
+            g.map_screen.show_message(tech_log.full_message)
 
         # Base complete dialogs.
         for base in bases_constructed:

--- a/code/player.py
+++ b/code/player.py
@@ -28,7 +28,8 @@ from numpy import array
 
 from code import g, difficulty, task, chance, location, group
 from code.buyable import cash, cpu
-from code.logmessage import LogEmittedEvent, LogResearchedTech, LogBaseLostMaintenance, LogBaseDiscovered
+from code.logmessage import LogEmittedEvent, LogResearchedTech, LogBaseLostMaintenance, LogBaseDiscovered, \
+    LogBaseConstructed
 from code.stats import itself as stats, observe
 
 
@@ -430,9 +431,10 @@ class Player(object):
 
         # Base complete dialogs.
         for base in bases_constructed:
-            text = g.strings["construction"] % {"base": base.name}
+            log_message = LogBaseConstructed(self.raw_sec, base.name, base.spec.id, base.location.id)
+            self.log.append(log_message)
             self.pause_game()
-            g.map_screen.show_message(text)
+            g.map_screen.show_message(log_message.full_message)
 
         # Item complete dialogs.
         for base, item in items_constructed:

--- a/code/player.py
+++ b/code/player.py
@@ -29,7 +29,7 @@ from numpy import array
 from code import g, difficulty, task, chance, location, group
 from code.buyable import cash, cpu
 from code.logmessage import LogEmittedEvent, LogResearchedTech, LogBaseLostMaintenance, LogBaseDiscovered, \
-    LogBaseConstructed
+    LogBaseConstructed, LogItemConstructionComplete
 from code.stats import itself as stats, observe
 
 
@@ -438,14 +438,11 @@ class Player(object):
 
         # Item complete dialogs.
         for base, item in items_constructed:
-            if item.count == 1:
-                text = g.strings["item_construction_single"] % \
-                       {"item": item.spec.name, "base": base.name}
-            else: # Just finished several items.
-                text = g.strings["item_construction_multiple"] % \
-                       {"item": item.spec.name, "base": base.name}
+            log_message = LogItemConstructionComplete(self.raw_sec, item.spec.id, item.count, base.name, base.spec.id,
+                                                      base.location.id)
+            self.log.append(log_message)
             self.pause_game()
-            g.map_screen.show_message(text)
+            g.map_screen.show_message(log_message.full_message)
 
         # Are we still in the grace period?
         grace = self.in_grace_period(self.had_grace)

--- a/code/savegame.py
+++ b/code/savegame.py
@@ -24,7 +24,7 @@ import cPickle
 import collections
 import os
 
-from code import g, mixer, dirs, player, group, data
+from code import g, mixer, dirs, player, group, data, logmessage
 from code import base, tech, item, event, location, buyable, difficulty, effect
 from code.stats import itself as stats
 
@@ -171,6 +171,7 @@ def load_savegame(savegame):
             ItemClass=item.ItemSpec,
             ItemSpec=item.ItemSpec,
             ItemType=item.ItemType,
+            LogEmittedEvent=logmessage.LogEmittedEvent,
             _reconstruct=numpy.core.multiarray._reconstruct,
             scalar=numpy.core.multiarray.scalar,
             ndarray=numpy.ndarray,

--- a/code/savegame.py
+++ b/code/savegame.py
@@ -176,6 +176,7 @@ def load_savegame(savegame):
             LogBaseLostMaintenance=logmessage.LogBaseLostMaintenance,
             LogBaseDiscovered=logmessage.LogBaseDiscovered,
             LogBaseConstructed=logmessage.LogBaseConstructed,
+            LogItemConstructionComplete=logmessage.LogItemConstructionComplete,
             _reconstruct=numpy.core.multiarray._reconstruct,
             scalar=numpy.core.multiarray.scalar,
             ndarray=numpy.ndarray,

--- a/code/savegame.py
+++ b/code/savegame.py
@@ -173,6 +173,8 @@ def load_savegame(savegame):
             ItemType=item.ItemType,
             LogEmittedEvent=logmessage.LogEmittedEvent,
             LogResearchedTech=logmessage.LogResearchedTech,
+            LogBaseLostMaintenance=logmessage.LogBaseLostMaintenance,
+            LogBaseDiscovered=logmessage.LogBaseDiscovered,
             _reconstruct=numpy.core.multiarray._reconstruct,
             scalar=numpy.core.multiarray.scalar,
             ndarray=numpy.ndarray,

--- a/code/savegame.py
+++ b/code/savegame.py
@@ -172,6 +172,7 @@ def load_savegame(savegame):
             ItemSpec=item.ItemSpec,
             ItemType=item.ItemType,
             LogEmittedEvent=logmessage.LogEmittedEvent,
+            LogResearchedTech=logmessage.LogResearchedTech,
             _reconstruct=numpy.core.multiarray._reconstruct,
             scalar=numpy.core.multiarray.scalar,
             ndarray=numpy.ndarray,

--- a/code/savegame.py
+++ b/code/savegame.py
@@ -175,6 +175,7 @@ def load_savegame(savegame):
             LogResearchedTech=logmessage.LogResearchedTech,
             LogBaseLostMaintenance=logmessage.LogBaseLostMaintenance,
             LogBaseDiscovered=logmessage.LogBaseDiscovered,
+            LogBaseConstructed=logmessage.LogBaseConstructed,
             _reconstruct=numpy.core.multiarray._reconstruct,
             scalar=numpy.core.multiarray.scalar,
             ndarray=numpy.ndarray,

--- a/code/screens/log.py
+++ b/code/screens/log.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 from code import g
 from code.graphics import dialog, constants, listbox
+from code.logmessage import AbstractLogMessage
 
 
 class LogScreen(dialog.ChoiceDialog):
@@ -40,12 +41,21 @@ class LogScreen(dialog.ChoiceDialog):
                                item_borders=False, item_selectable=False)
 
     def show(self):
-        self.list = ["%s -- %s" % (_("DAY") + " %04d, %02d:%02d:%02d" % log[0],
-                                   self.create_log_text(log[1], log[2])) for log in g.pl.log]
+        self.list = [self.render_log_message(message) for message in g.pl.log]
 
         self.default = len(self.list) - 1
 
         return super(LogScreen, self).show()
+
+    def render_log_message(self, message):
+        if isinstance(message, AbstractLogMessage):
+            log_emit_time = message.log_emit_time
+            log_message = message.log_line
+        else:
+            # Old style messages
+            log_emit_time = message[0]
+            log_message = self.create_log_text(message[1], message[2])
+        return "%s -- %s" % (_("DAY") + " %04d, %02d:%02d:%02d" % log_emit_time, log_message)
 
     def create_log_text(self, log_name, log_data):
         """ Dispatch log to a function.

--- a/code/screens/log.py
+++ b/code/screens/log.py
@@ -38,7 +38,20 @@ class LogScreen(dialog.ChoiceDialog):
     def make_listbox(self):
         return listbox.Listbox(self, (0, 0), (-1, -.85),
                                anchor=constants.TOP_LEFT, align=constants.LEFT,
-                               item_borders=False, item_selectable=False)
+                               on_double_click_on_item=self.handle_double_click,
+                               item_borders=False, item_selectable=True)
+
+    def handle_double_click(self, event):
+        if self.listbox.is_over(event.pos) and 0 <= self.listbox.list_pos < len(g.pl.log):
+            message = g.pl.log[self.listbox.list_pos]
+            message_dialog = dialog.MessageDialog(self, text_size=20)
+            if isinstance(message, AbstractLogMessage):
+                message_dialog.text = message.full_message
+                message_dialog.color = message.full_message_color
+            else:
+                # Old style message; fall back to rendering the log line
+                message_dialog.text = self.create_log_text(message[1], message[2])
+            dialog.call_dialog(message_dialog, self)
 
     def show(self):
         self.list = [self.render_log_message(message) for message in g.pl.log]


### PR DESCRIPTION
With this branch, it will be possible to re-read messages (in full) via the log menu by double clicking on the log line.

Known issues:
- [x] Old save games may not work/convert properly (We bump the version and clear the old logs)
- [x] Use one shared set of named arguments
- [x] Solve the message ID problem (done in 39c85b7)
- [x] Events do not (yet) have a full message