### PR TITLE
Add a way to reload themes from disk in game

### DIFF
--- a/code/graphics/dialog.py
+++ b/code/graphics/dialog.py
@@ -273,6 +273,18 @@ class Dialog(text.Text):
                     g.set_fullscreen(not g.fullscreen)
                     Dialog.top.needs_resize = True
 
+            elif event.key == pygame.K_F5:
+                if event.type == pygame.KEYDOWN:
+                    import code.graphics.theme as theme
+                    if theme.current:
+                        import code.data as data
+                        theme_id = theme.current.id
+                        theme.themes.clear()
+                        data.load_themes()
+                        # Use set_theme with force to ensure the theme is reloaded
+                        # NB: theme.current points to the "pre-reload" version, so
+                        # theme.current.update() will not work here.
+                        theme.set_theme(theme_id, force_reload=True)
             elif event.type == pygame.KEYDOWN:
                 # Generic keydown handlers.
                 insort_all(handlers, self.handlers.get(constants.KEYDOWN, []))

--- a/code/graphics/theme.py
+++ b/code/graphics/theme.py
@@ -32,7 +32,7 @@ def get_theme_list():
 def get_theme_pos():
     return (i[0] for i in enumerate(themes) if i[1] == current.id).next()
 
-def set_theme(key):
+def set_theme(key, force_reload=False):
     global current
     theme = None
 
@@ -55,7 +55,7 @@ def set_theme(key):
         sys.stderr.write("WARNING: The key '%s' does not exist in theme dictionnary. Use default theme.\n" % key)
         theme = themes[default_theme]
 
-    if (not current == None and theme.id != current.id):
+    if force_reload or (not current == None and theme.id != current.id):
         theme.update()
     current = theme
 


### PR DESCRIPTION
While working on developing a theme, I got frustrated over having to restart singularity so many times for tweaking colors.  It would have been much easier to do if you could simply hit a button and singularity would reload the theme plus reapply it immediately.  This PR does this (arbitrarily) using F5 as "global" hotkey for this purpose (I picked it as I thought of it as a "Refresh" in the browser).

Note that if there is a mistake in the theme (e.g. a typo a color), singularity will crash immediately (like it does when it renders a broken theme).