### PR TITLE
Fix invalid encoded character

### DIFF
--- a/code/graphics/dialog.py
+++ b/code/graphics/dialog.py
@@ -268,7 +268,7 @@ class Dialog(text.Text):
             # TODO: Dynamize global key handlers.
             # TODO: Allows customization of global key handlers.
             # Important: Global key handlers should always be a combination 
-            # of two keys or F# keys.
+            # of two keys or F# keys.
             if event.key == pygame.K_RETURN and pygame.key.get_mods() & pygame.KMOD_ALT:
                 if event.type == pygame.KEYDOWN:
                     g.set_fullscreen(not g.fullscreen)


### PR DESCRIPTION
An invalid encoded (whitespace?) character appeared in b5e37bb5a78c8f2e1a477da029903f4132c40e8e, which causes singularity to crash on start up.  This branch should fix said crash.