### PR TITLE
Improve double-clicking on items in listbox dialogs

### DIFF
--- a/TODO
+++ b/TODO
@@ -12,7 +12,6 @@ TODO:
     - Add more items.
     - Covert most data/strings_ll_CC.dat entries to new messages_ll_CC.po style
       Long entries like [help] and [jobs] section could have their own files
-    - Make it so that double-click is equivalent to 'OK' in dialogs. (rubikcube)
     - Consistent use of stderr and print, preferably using available Logger
     - Fix hotkeys and reload all dialogs and buttons when language changes, or
       provide Options Screen a way to restart the game

--- a/code/graphics/dialog.py
+++ b/code/graphics/dialog.py
@@ -619,19 +619,15 @@ class ChoiceDialog(YesNoDialog):
 
         super(ChoiceDialog, self).__init__(parent, *args, **kwargs)
 
-        self.listbox = self.make_listbox()
-        self.add_handler(constants.DOUBLECLICK, self.handle_double_click, 200)
-
         self.yes_button.exit_code_func = self.return_list_pos
         self.no_button.exit_code = None
-
-    def handle_double_click(self, event):
-        if self.listbox.is_over(event.pos):
-            self.yes_button.activated(None)
+        self.listbox = self.make_listbox()
 
     def make_listbox(self):
         return listbox.Listbox(self, (0, 0), (-1, -.85),
-                               anchor=constants.TOP_LEFT)
+                               anchor=constants.TOP_LEFT,
+                               on_double_click_on_item=self.yes_button.activated,
+                               )
 
     def return_list_pos(self):
         return self.listbox.list_pos

--- a/code/screens/location.py
+++ b/code/screens/location.py
@@ -37,15 +37,19 @@ class LocationScreen(dialog.Dialog):
         self.size = (-.75, -.5)
         self.name_display = text.Text(self, (0,0), (-1, -.08),
                                       background_color="clear")
-        self.listbox = listbox.CustomListbox(self, (0,-.08), (-1, -.70),
-                                             remake_func=self.make_item,
-                                             rebuild_func=self.update_item)
 
         self.open_button = \
             button.FunctionButton(self, (0, -.8), (-.3, -.09),
                                   anchor=constants.TOP_LEFT,
                                   autohotkey=True,
                                   function=self.open_base)
+
+
+        self.listbox = listbox.CustomListbox(self, (0,-.08), (-1, -.70),
+                                             remake_func=self.make_item,
+                                             rebuild_func=self.update_item,
+                                             on_double_click_on_item=self.open_button.activated,
+                                             )
 
         self.rename_button = \
             button.FunctionButton(self, (-.50, -.8), (-.3, -.09),

--- a/code/screens/savegame.py
+++ b/code/screens/savegame.py
@@ -42,7 +42,9 @@ class SavegameScreen(dialog.ChoiceDialog):
         return listbox.CustomListbox(self, (0, 0), (-1, -.85),
                                      anchor=constants.TOP_LEFT,
                                      remake_func=self.make_item,
-                                     rebuild_func=self.update_item)
+                                     rebuild_func=self.update_item,
+                                     on_double_click_on_item=self.yes_button.activated,
+                                     )
 
     def make_item(self, item):
         item.name_display     = text.Text(item, (-.01,-.05), (-.45, -.99),


### PR DESCRIPTION
This branch makes two user visible improvements to the double-handling of listbox-based dialogs:

 * Double-clicking on an item in the "Location" menu menu now acts as "Open Base"
 * Double-click handling now *only* triggers if you double-click on an actual (and not just an "empty" row in the listbox)

Internally, we also centralize the double-click handling in the listbox widget to ensure the behaviour is consistent across all listbox-based dialogs reacting to double-clicking.