### PR TITLE
Rewrite loading of techs to support adding new techs

### DIFF
--- a/code/savegame.py
+++ b/code/savegame.py
@@ -164,7 +164,7 @@ def load_savegame(savegame):
     g.pl = unpickle.load()
     g.curr_speed = unpickle.load()
     loaded_techs = unpickle.load()
-    g.locations = unpickle.load()
+    loaded_locations = unpickle.load()
     g.events = unpickle.load()
 
     import data
@@ -172,11 +172,12 @@ def load_savegame(savegame):
     # the technologies from the current version of the game.  We will then merge
     # relevant state from the save game into the g.techs table below.
     data.load_techs()
+    data.load_locations()
 
     # Changes to individual pieces go here.
     if load_version != savefile_translation[current_save_version]:
         g.pl.convert_from(load_version)
-        for my_location in g.locations.values():
+        for my_location in loaded_locations.values():
             for my_base in my_location.bases:
                 my_base.convert_from(load_version)
                 for my_item in my_base.all_items():
@@ -202,6 +203,14 @@ def load_savegame(savegame):
             tech.cost_paid = tech.total_cost
         else:
             tech.cost_paid = tech_from_savegame.cost_paid
+
+    for location_id, location_from_savegame in loaded_locations.items():
+        location = g.locations.get(location_id)
+        if location is None:
+            # Discard bases at (now) unknown locations.
+            continue
+        # We avoid "add_base" because savegames have pre-applied bonuses
+        location.bases.extend(location_from_savegame.bases)
 
     data.reload_all_mutable_def()
 


### PR DESCRIPTION
Previously, when we load a savegame, the program would assume that the
savegame contained all the *current* technologies.  However, this
assumption fails every time a new technology is added to singularity
and then singularity simply crashes.

This patch solves this by pulling all techs from the data files and
then merging the few relevant bits ("done" and "cost_paid" from the
savegame) into the existing saves. Obsolete techs (i.e. techs prevent
in the savegame but not in the data files) are ignored to avoid
crashing on them.  In the case, where a technology is renamed, we can
preserve it by correcting it's "id" in the convert_from method.

With this patch, a save game made on commit b16134996 can still be
successfully loaded in 03b0bd51e8, where a new tech is introduced.

Signed-off-by: Niels Thykier <niels@thykier.net>