### PR TITLE
Split Location into a stateful part and LocationSpec

### DIFF
--- a/code/data.py
+++ b/code/data.py
@@ -359,7 +359,7 @@ def load_locations():
         modifiers_dict = read_modifiers_dict(location_info.get("modifier", []))
 
         # Create the location.
-        locations[id] = location.Location(id, position, absolute, safety, pre)
+        locations[id] = location.LocationSpec(id, position, absolute, safety, pre)
         locations[id].modifiers = modifiers_dict
 
         # Add the location to regions it is in them.

--- a/code/g.py
+++ b/code/g.py
@@ -205,7 +205,7 @@ def to_time(raw_time):
 
 # Generator function for iterating through all bases.
 def all_bases(with_loc = False):
-    for base_loc in locations.values():
+    for base_loc in pl.locations.values():
         for base in base_loc.bases:
             if with_loc:
                 yield (base, base_loc)
@@ -242,7 +242,7 @@ def new_game(difficulty_name):
 
     #Starting base
     import base
-    open = [loc for loc in locations.values() if loc.available()]
+    open = [loc for loc in pl.locations.values() if loc.available()]
     random.choice(open).add_base(base.Base(_("University Computer"),
                                  base_type["Stolen Computer Time"], built=True))
 
@@ -250,7 +250,7 @@ def new_game(difficulty_name):
     for reg in regions.itervalues():
         random.shuffle(reg.modifiers_list)
         for mod, loc in zip(reg.modifiers_list, reg.locations):
-            locations[loc].modifiers = mod
+            pl.locations[loc].modifiers = mod
             if debug:
                 print "%s gets modifiers %s" % (loc, mod)
 

--- a/code/savegame.py
+++ b/code/savegame.py
@@ -190,17 +190,15 @@ def load_savegame(savegame):
     g.pl = unpickle.load()
     g.curr_speed = unpickle.load()
     g.techs = unpickle.load()
-    g.locations = unpickle.load()
+    if load_version < 99.7:
+        # In >= 99.8 locations are saved as a part of the player object, but earlier
+        # it was stored as a separate part of the stream.
+        g.pl.locations = unpickle.load()
     g.events = unpickle.load()
 
     # Changes to individual pieces go here.
     if load_version != savefile_translation[current_save_version]:
         g.pl.convert_from(load_version)
-        for my_location in g.locations.values():
-            for my_base in my_location.bases:
-                my_base.convert_from(load_version)
-                for my_item in my_base.all_items():
-                    my_item.convert_from(load_version)
         for my_group in g.pl.groups.values():
             my_group.convert_from(load_version)
         for my_tech in g.techs.values():
@@ -239,7 +237,6 @@ def create_savegame(savegame_name):
         cPickle.dump(g.pl, savefile)
         cPickle.dump(g.curr_speed, savefile)
         cPickle.dump(g.techs, savefile)
-        cPickle.dump(g.locations, savefile)
         cPickle.dump(g.events, savefile)
 
 

--- a/code/screens/map.py
+++ b/code/screens/map.py
@@ -583,7 +583,7 @@ class MapScreen(dialog.Dialog):
         self.set_speed(speeds[new_index])
 
     def open_location(self, location):
-        self.location_dialog.location = g.locations[location]
+        self.location_dialog.location = g.pl.locations[location]
         dialog.call_dialog(self.location_dialog, self)
         return
 
@@ -791,7 +791,7 @@ class MapScreen(dialog.Dialog):
         self.danger_bar.visible = not g.pl.had_grace
 
         for id, location_button in self.location_buttons.iteritems():
-            location = g.locations[id]
+            location = g.pl.locations[id]
             location_button.text = "%s (%d)" % (location.name, len(location.bases))
             location_button.hotkey = location.hotkey
             location_button.visible = location.available()


### PR DESCRIPTION
This splits Location into a stateful part (still called Location) and
spec.  The stateful part is moved to the player object and all
references to it is updated to follow.

Signed-off-by: Niels Thykier <niels@thykier.net>