### PR TITLE
Reduce file descriptor usage due to fonts

### DIFF
--- a/code/graphics/g.py
+++ b/code/graphics/g.py
@@ -157,13 +157,36 @@ def set_mode():
     return pygame.display.set_mode(real_screen_size, flags)
 
 
-def load_font(filename):
-    font = ([0] * 100)
-    font[0] = filename
-    for i in range(100):
-        font[i] = pygame.font.Font(filename, i)
+class LazyFontList(object):
+    """Lazy loader for fonts to reduce the file descriptor pressure
 
-    return font
+    Each font item apparently reserves a file descriptor (see GH#156)
+    """
+
+    def __init__(self, filename, max_size=100):
+        self._filename = filename
+        self._font_cache = {}
+        self._max_size = max_size
+
+    def __len__(self):
+        return self._max_size
+
+    def __contains__(self, item):
+        return 0 <= item < self._max_size
+
+    def __getitem__(self, item):
+        font = self._font_cache.get(item)
+        if font is None:
+            if item < 0 or self._max_size <= item:
+                raise IndexError(item)
+            font = pygame.font.Font(self._filename, item)
+            self._font_cache[item] = font
+        return font
+
+
+def load_font(filename):
+    return LazyFontList(filename)
+
 
 def load_image(filename):
     # We need to convert the image to a Pygame image surface and


### PR DESCRIPTION
Mitigates #156 by only loading the font sizes we need as we need them.
With this, we go from loading 200 instances of Font to less than 70
at the start of the game.

Signed-off-by: Niels Thykier <niels@thykier.net>