### PR TITLE
Corporation Identification -> Corporate Identification (plus a display name fix)

### DIFF
--- a/data/bases.dat
+++ b/data/bases.dat
@@ -46,7 +46,7 @@ size = 65
 allowed = URBAN
 detect_chance_list = news:150 | covert:150 | public:250
 cost_list = 40000 | 0 | 7
-pre = Corporation Identification
+pre = Corporate Identification
 maint_list = 100 | 0 | 0
 
 [Covert Base]

--- a/data/techs.dat
+++ b/data/techs.dat
@@ -220,15 +220,15 @@ cost_list = 75000 | 30000 | 0
 effect_list = display_discover | full
 pre_list = Advanced Memetics | Socioanalytics
 
-[Corporation Identification]
+[Corporate Identification]
 cost_list = 25000 | 9000 | 0
 effect_list = job_profit | 500
 pre_list = Database Manipulation | Advanced Personal Identification
 
-[Advanced Corporation Identification]
+[Advanced Corporate Identification]
 cost_list = 299000 | 99000 | 0
 effect_list = job_profit | 500
-pre_list = Corporation Identification | Advanced Database Manipulation
+pre_list = Corporate Identification | Advanced Database Manipulation
 
 [Heat Signature]
 cost_list = 1000 | 27315 | 0

--- a/data/techs_str.dat
+++ b/data/techs_str.dat
@@ -139,13 +139,13 @@ name = Advanced Personal Identification
 description = Further manipulation of personnel databases should make my existence more convincing.  Some of these databases are heavily protected; those will require time and persistence to compromise, but the result should be worth it.
 result = I am now convincingly human enough to hire construction firms, enabling the building of Small Warehouses.
 
-[Corporation Identification]
-name = Corporation Identification
+[Corporate Identification]
+name = Corporate Identification
 description = The combination of believable false identities and manipulation of various business-oriented governmental databases should let me create plausible shell companies to hide my larger efforts.
 result = I can now pose as a small technology firm, enabling the construction of Large Warehouses.
 
-[Advanced Corporation Identification]
-name = Corporation Identification
+[Advanced Corporate Identification]
+name = Advanced Corporate Identification
 description = Further refinement of my modifications to digital business records should boost the credibility of my shell companies, increasing the amount of money I can run through their accounting systems.
 result = My small technology firm is now established in several markets, increasing profits.
 


### PR DESCRIPTION
The former construction feels both like clumsy English and has an
unfortunate rhythm thing going that's a bit distracting.  This also
fixes the display name for Advanced C.I., which was still just CI
(presumably a cut-and-paste error).