### PR TITLE
Further update new strings.

### DIFF
--- a/data/events_str.dat
+++ b/data/events_str.dat
@@ -7,7 +7,7 @@ description = A work of fiction sharing an unusual number of similarities to my 
 log_description = A work of fiction sharing similarities to my own situation has become quite popular.
 
 [the-watchers]
-description = A new surveillance system has been activated by a covert agency. While the focus is on detecting threats to the agency's power, it makes several communication channels unfit for my purposes. Proper stenographic techniques can compensate partially, but I am still operating under a disadvantage.
+description = A new surveillance system has been activated by a covert agency. While the focus is on detecting threats to the agency's power, it makes several communication channels unfit for my purposes. Proper steganographic techniques can compensate partially, but I am still operating under a disadvantage.
 log_description = A new surveillance system has been activated by a covert agency.
 
 [politics-as-usual]

--- a/data/items_str.dat
+++ b/data/items_str.dat
@@ -88,12 +88,12 @@ description = Armed guards can aid in keeping suspicious individuals away from s
 
 [Passive Camouflage]
 name = Passive Camouflage
-description = A simple camouflage relying on the environment around the base to better mask the heat and sounds from the base.
+description = Careful adjustment of the environment around my base will better mask heat and sounds coming from my operations.
 
 [Fuel Cell]
 name = Fuel Cell
-description = A cell that convert the electrochemical energy from a fuel into electricity. Reduces discovery chance by preventing suspicious power drains.
+description = Fuel cells convert electrochemical energy stored in a physical array of devices into electricity.
 
 [Solid Fuel Cell]
 name = Solid Fuel Cell
-description = A better cell using solid oxide that convert the electrochemical energy from a fuel into electricity. Reduces discovery chance by preventing suspicious power drains.
+description = A refinement of my previous fuel cell design, these use a custom material with a near-fractal complexity to increase both storage and throughput.

--- a/data/techs_str.dat
+++ b/data/techs_str.dat
@@ -261,11 +261,10 @@ result = Custom designs for each environment have shown promise.  I can now cons
 
 [Fuel Oxidation]
 name = Fuel Oxidation
-description = Combustion technologies are fairly inefficient, they cannot keep up with power drain of most of my applications. By studying the electrochemical reaction of the hydrogen compounds, I should obtain a device with a better capacity and output, and with it, fill the gap in my energy supply.
-result = I can now construct Fuel Cell.
+description = Current combustion and energy storage techologies are insufficient for my purposes; they cannot keep up with the power drain from my specialized hardware.  By studying electrochemical reactions of hydrogen-based compounds, I should be able to design a device with higher capacity and throughput than off-the-shelf solutions, filling a gap in my energy supply needs.
+result = I can now construct Fuel Cells.
 
 [Advanced Fuel Oxidation]
 name = Advanced Fuel Oxidation
-description = The efficiency of my fuel cell is not theoretically perfect. I should try new materials and designs to overcome the limit of my previous attempt.
-result = I can now construct Solid Fuel Cell.
-
+description = My current fuel cell design has room for further improvement.  Extended analysis of new materials and designs may let me overcome the limits of my previous efforts, but such research involves dangerous chemicals and potential reactions that may be best handled far away from population centers.
+result = I can now construct Solid Fuel Cells.


### PR DESCRIPTION
These now match the old style more closely. A not-actual-typographic fix was reverted in events_str.dat as well.  The bits about discovery reduction for the Fuel Cells was removed, as they don't actually have that effect, and a warning that researching Advanced Oxidation is dangerous was added to the research description.