### PR TITLE
Rewrite data loading code for  Spec classes

### DIFF
--- a/code/base.py
+++ b/code/base.py
@@ -31,18 +31,41 @@ from code.buyable import cpu
 #      (Base.power_state would need to be a property, with setter and getter)
 #This list only applies to 'Base' class, not 'BaseClass'
 #Changes to this list should also be reflected in Base.power_state_name property
+from code.spec import SpecDataField, promote_to_list, validate_must_be_list
+
 power_states = ['active','sleep']
 #power_states.extend(['overclocked','suicide','stasis','entering_stasis','leaving_stasis'])
+
+
+def parse_detect_chance(parsed_value):
+    validate_must_be_list(parsed_value)
+    chance_dict = {}
+
+    for chance_str in parsed_value:
+        key, value = chance_str.split(":")
+        chance_dict[key] = int(value)
+
+    return chance_dict
 
 
 class BaseSpec(buyable.BuyableSpec):
     """Base as a buyable item (New Base in Location menu)"""
 
     spec_type = 'base'
+    spec_data_fields = [
+        SpecDataField('size', converter=int),
+        SpecDataField('force_cpu', default_value=None),
+        SpecDataField('regions', data_field_name='allowed', converter=promote_to_list),
+        SpecDataField('detect_chance', converter=parse_detect_chance),
+        buyable.SPEC_FIELD_COST,
+        buyable.SPEC_FIELD_PREREQUISITES,
+        SpecDataField('danger', converter=int, default_value=0),
+        SpecDataField('maintenance', data_field_name='maint', converter=buyable.spec_parse_cost),
+    ]
 
-    def __init__(self, name, size, force_cpu, regions,
-                        detect_chance, cost, prerequisites, maintenance):
-        super(BaseSpec, self).__init__(name, cost, prerequisites)
+    def __init__(self, id, size, force_cpu, regions,
+                 detect_chance, cost, prerequisites, maintenance):
+        super(BaseSpec, self).__init__(id, cost, prerequisites)
         self.size = size
         self.force_cpu = force_cpu
         self.regions = regions

--- a/code/buyable.py
+++ b/code/buyable.py
@@ -21,7 +21,7 @@
 from __future__ import absolute_import
 
 from operator import truediv
-from code import g
+from code import g, spec
 from code import prerequisite
 
 cash, cpu, labor = range(3)
@@ -30,11 +30,26 @@ import numpy
 numpy.seterr(all='ignore')
 array = numpy.array
 
-class BuyableSpec(prerequisite.Prerequisite):
-    def __init__(self, id, cost, prerequisites):
-        super(BuyableSpec, self).__init__(prerequisites)
 
-        self.name = self.id = id
+def spec_parse_cost(value):
+    spec.validate_must_be_list(value)
+    if len(value) != 3:  # pragma: no cover
+        raise ValueError("Cost must have exactly 3 values (CPU, money, time), got %d items (value: %s)" % (
+            len(value), repr(value)))
+    return [int(x) for x in value]
+
+
+SPEC_FIELD_PREREQUISITES = spec.SpecDataField('prerequisites', data_field_name='pre', converter=spec.promote_to_list,
+                                              default_value=list)
+SPEC_FIELD_COST = spec.SpecDataField('cost', converter=spec_parse_cost)
+
+
+class BuyableSpec(spec.GenericSpec, prerequisite.Prerequisite):
+    def __init__(self, id, cost, prerequisites):
+        spec.GenericSpec.__init__(self, id)
+        prerequisite.Prerequisite.__init__(self, prerequisites)
+
+        self.name = id
         # This will be set when languages are (re)loaded
         self.description = ''
         self._cost = cost

--- a/code/data.py
+++ b/code/data.py
@@ -509,15 +509,12 @@ def load_events():
             sys.stderr.write("Error with effects given: %s\n" % repr(effect_list))
             sys.exit(1)
 
+        event_id = event_name["id"]
+        event_spec = event.EventSpec(event_name["id"], event_name["type"], effect_list,
+                                     int(event_name["chance"]), int(event_name["unique"]))
+
         # Build the actual event object.
-        events[event_name["id"]] = event.Event(
-         event_name["id"],
-         "",
-         "",
-         event_name["type"],
-         effect_list,
-         int(event_name["chance"]),
-         int(event_name["unique"]))
+        events[event_id] = event.Event(event_spec)
 
     load_event_defs()
 

--- a/code/data.py
+++ b/code/data.py
@@ -423,8 +423,10 @@ def load_techs():
         else:
             effect_list = []
 
-        techs[tech_name["id"]]=tech.Tech(tech_name["id"],
-         tech_cost, tech_pre, tech_danger, effect_list)
+        tech_id = tech_name['id']
+        tech_spec = tech.TechSpec(tech_id, tech_cost, tech_pre, tech_danger,
+                                  effect_list)
+        techs[tech_id] = tech.Tech(tech_spec)
 
     if g.debug: print("Loaded %d techs." % len (techs))
 

--- a/code/event.py
+++ b/code/event.py
@@ -21,14 +21,22 @@
 from __future__ import absolute_import
 
 from code import g, effect
+from code.spec import GenericSpec, SpecDataField, spec_field_effect
 
 
-class EventSpec(object):
+class EventSpec(GenericSpec):
 
-    def __init__(self, id, event_type, effects, chance, unique):
-        self.id = id
+    spec_data_fields = [
+        SpecDataField('event_type', data_field_name='type'),
+        spec_field_effect(mandatory=True),
+        SpecDataField('chance', converter=int),
+        SpecDataField('unique', converter=int),
+    ]
+
+    def __init__(self, id, event_type, effect_data, chance, unique):
+        super(EventSpec, self).__init__(id)
         self.event_type = event_type
-        self.effect = effect.Effect(self, effects)
+        self.effect = effect.Effect(self, effect_data)
         self.chance = chance
         self.unique = unique
 

--- a/code/event.py
+++ b/code/event.py
@@ -37,11 +37,10 @@ class Event(object):
     # For some as-yet-unknown reason, cPickle decides to call event.__init__()
     # when an event is loaded, but before filling it.  So Event pretends to
     # allow no arguments, even though that would cause Bad Things to happen.
-    def __init__(self, id=None, description=None, log_description=None, event_type=None,
-                 effects=None, chance=None, unique=None):
-        self.spec = EventSpec(id, event_type, effects, chance, unique)
-        self.description = description
-        self.log_description = log_description
+    def __init__(self, spec=None):
+        self.spec = spec
+        self.description = ""
+        self.log_description = ""
         self.triggered = 0
 
     @property

--- a/code/event.py
+++ b/code/event.py
@@ -23,20 +23,46 @@ from __future__ import absolute_import
 from code import g, effect
 
 
+class EventSpec(object):
+
+    def __init__(self, id, event_type, effects, chance, unique):
+        self.id = id
+        self.event_type = event_type
+        self.effect = effect.Effect(self, effects)
+        self.chance = chance
+        self.unique = unique
+
+
 class Event(object):
     # For some as-yet-unknown reason, cPickle decides to call event.__init__()
     # when an event is loaded, but before filling it.  So Event pretends to
     # allow no arguments, even though that would cause Bad Things to happen.
     def __init__(self, id=None, description=None, log_description=None, event_type=None,
                  effects=None, chance=None, unique=None):
-        self.event_id = self.name = self.id = id
+        self.spec = EventSpec(id, event_type, effects, chance, unique)
         self.description = description
         self.log_description = log_description
-        self.event_type = event_type
-        self.effect = effect.Effect(self, effects)
-        self.chance = chance
-        self.unique = unique
         self.triggered = 0
+
+    @property
+    def event_id(self):
+        return self.spec.event_id
+
+    @property
+    def event_type(self):
+        return self.spec.event_type
+
+    @property
+    def effect(self):
+        return self.spec.effect
+
+    @property
+    def chance(self):
+        return self.spec.chance
+
+    @property
+    def unique(self):
+        return self.spec.unique
 
     def convert_from(self, old_version):
         if old_version < 99: # < 1.0dev

--- a/code/group.py
+++ b/code/group.py
@@ -22,12 +22,17 @@
 from __future__ import absolute_import
 
 from code import g
+from code.spec import GenericSpec, SpecDataField
 
 
-class GroupSpec(object):
+class GroupSpec(GenericSpec):
 
-    def __init__(self, people_id, suspicion_decay = 100):
-        self.id = people_id
+    spec_data_fields = [
+        SpecDataField('suspicion_decay', converter=int, default_value=100)
+    ]
+
+    def __init__(self, id, suspicion_decay):
+        super(GroupSpec, self).__init__(id)
         self.suspicion_decay = suspicion_decay
         self.discover_suspicion = 1000
         

--- a/code/item.py
+++ b/code/item.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 import collections
 
 from code import g, buyable
+from code.spec import SpecDataField, validate_must_be_list, promote_to_list
 
 
 class ItemType(object):
@@ -73,21 +74,40 @@ item_types = collections.OrderedDict([
     ("security", ItemType("security")),
 ])
 
+
 def all_types():
     for item_type in item_types.itervalues():
         yield item_type
+
+
+def convert_item_type(raw_value):
+    validate_must_be_list(raw_value)
+    if len(raw_value) != 2:  # pragma: no cover
+        raise ValueError("item type must be exactly 2 elements, got %d (value: %s)" % (len(raw_value), repr(raw_value)))
+    item_type_id, item_qual = raw_value
+    try:
+        item_type = item_types[item_type_id]
+    except KeyError:  # pragma: no cover
+        raise ValueError("Unknown item type %s, please use one of: %s" % (item_type_id, ", ".join(item_types)))
+    return item_type, int(item_qual)
+
 
 class ItemSpec(buyable.BuyableSpec):
     """ Item as a buyable item (CPUs, Reactors, Network and Security items) """
 
     spec_type = 'item'
+    spec_data_fields = [
+        buyable.SPEC_FIELD_COST,
+        buyable.SPEC_FIELD_PREREQUISITES,
+        SpecDataField('item_type_info', data_field_name='type', converter=convert_item_type),
+        SpecDataField('buildable', data_field_name='build', converter=promote_to_list, default_value=list),
+    ]
 
-    def __init__(self, name, cost, prerequisites, item_type,
-            item_qual, buildable):
-        super(ItemSpec, self).__init__(name, cost, prerequisites)
+    def __init__(self, id, cost, prerequisites, item_type_info, buildable):
+        super(ItemSpec, self).__init__(id, cost, prerequisites)
 
-        self.item_type = item_types[item_type]
-        self.item_qual = item_qual
+        # The "type" field in the data file expands to more than one field
+        self.item_type, self.item_qual = item_type_info
         self.regions = buildable
 
     def get_info(self):

--- a/code/spec.py
+++ b/code/spec.py
@@ -1,0 +1,104 @@
+#file: spec.py
+#Copyright (C) 2005,2006,2007,2008 Evil Mr Henry, Phil Bordelon, Brian Reid,
+#                        and FunnyMan3595
+#This file is part of Endgame: Singularity.
+
+#Endgame: Singularity is free software; you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation; either version 2 of the License, or
+#(at your option) any later version.
+
+#Endgame: Singularity is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with Endgame: Singularity; if not, write to the Free Software
+#Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#This file contains class to handle basic functionality of Spec's
+
+import inspect
+
+
+UNSET = object()
+
+
+class InvalidDataEntryError(RuntimeError):
+    pass
+
+
+def promote_to_list(value):
+    if not isinstance(value, list):
+        return [value]
+    return value
+
+
+def validate_must_be_list(value):
+    if type(value) != list:  # pragma: no cover
+        raise TypeError("Must be list, got type %s (value: %s)" % (type(value), repr(value)))
+
+
+class SpecDataField(object):
+
+    def __init__(self, field_name, data_field_name=None, mandatory=None, converter=None, validator=None,
+                 default_value=UNSET):
+        self.field_name = field_name
+        self.data_field_name = data_field_name if data_field_name is not None else field_name
+        self.mandatory = mandatory
+        self.default_value = default_value
+        if self.mandatory is None:
+            self.mandatory = True if default_value is UNSET else False
+        self.converter = converter
+        self.validator = validator
+        assert self.mandatory or default_value is not UNSET, "%s (field: %s) must either be mandatory or have a " \
+                                                             "default_value" % (self.__class__.__name__, field_name)
+        assert not converter or not validator, "%s (field: %s) at can most have one of converter or validator" % \
+                                               (self.__class__.__name__, field_name)
+
+    def parse_data_field(self, raw_data_set, data_reference):
+        try:
+            value = raw_data_set[self.data_field_name]
+        except KeyError:
+            if self.mandatory:  # pragma: no cover
+                raise InvalidDataEntryError("Missing mandatory data field %s (field name: %s) for %s" % (
+                    self.data_field_name, self.field_name, data_reference))
+            if callable(self.default_value):
+                return self.default_value()
+            return self.default_value
+
+        if self.validator:
+            self.validator(value)
+        if self.converter:
+            value = self.converter(value)
+        return value
+
+
+def spec_field_effect(mandatory=True):
+    return SpecDataField('effect_data', data_field_name='effect', mandatory=mandatory, validator=list,
+                         default_value=list)
+
+
+class GenericSpec(object):
+
+    spec_data_fields = None
+
+    def __init__(self, id):
+        self.id = id
+        assert self.__class__.spec_data_fields is not None, "Class %s is missing spec_data_field" % \
+                                                            self.__class__.__name__
+
+    @classmethod
+    def create_from_data_file(cls, data_id, spec_data):
+        named_fields = {
+            f.field_name: f.parse_data_field(spec_data, data_id)
+            for f in cls.spec_data_fields
+        }
+        named_fields['id'] = data_id
+        # Use reflection to call the constructor with the arguments
+        # properly aligned
+        arg_desc = inspect.getargspec(cls.__init__)
+        args = [named_fields[name] for name in arg_desc.args[1:]]
+        return cls(*args)
+

--- a/code/tech.py
+++ b/code/tech.py
@@ -36,10 +36,7 @@ class TechSpec(buyable.BuyableSpec):
 
 class Tech(buyable.Buyable):
 
-    def __init__(self, id, cost, prerequisites, danger,
-                 effect_data):
-        # A bit silly, but it does the trick.
-        spec = TechSpec(id, cost, prerequisites, danger, effect_data)
+    def __init__(self, spec):
         super(Tech, self).__init__(spec)
 
         self.result = ""

--- a/code/tech.py
+++ b/code/tech.py
@@ -21,10 +21,17 @@
 from __future__ import absolute_import
 
 from code import buyable, effect
+from code.spec import SpecDataField, spec_field_effect
 
 
 class TechSpec(buyable.BuyableSpec):
     spec_type = 'tech'
+    spec_data_fields = [
+        buyable.SPEC_FIELD_COST,
+        buyable.SPEC_FIELD_PREREQUISITES,
+        SpecDataField('danger', converter=int, default_value=0),
+        spec_field_effect(mandatory=False),
+    ]
 
     def __init__(self, id, cost, prerequisites, danger,
                  effect_data):

--- a/data/events.dat
+++ b/data/events.dat
@@ -5,56 +5,48 @@
 
 [the-plague]
 type = global
-allowed = all
 effect_list = discover | public | 1000
 chance = 20
 unique = 1
 
 [stranger-than-fiction]
 type = global
-allowed = all
 effect_list = discover | public | -1000
 chance = 20
 unique = 1
 
 [the-watchers]
 type = global
-allowed = all
 effect_list = discover | covert | -1000
 chance = 20
 unique = 1
 
 [politics-as-usual]
 type = global
-allowed = all
 effect_list = discover | covert | 1000
 chance = 20
 unique = 1
 
 [lab-ai]
 type = global
-allowed = all
 effect_list = discover | science | -1000
 chance = 20
 unique = 1
 
 [discrediting]
 type = global
-allowed = all
 effect_list = discover | science | 1000
 chance = 20
 unique = 1
 
 [scandal]
 type = global
-allowed = all
 effect_list = discover | news | 1000
 chance = 20
 unique = 0
 
 [investigation]
 type = global
-allowed = all
 effect_list = discover | news | -1000
 chance = 20
 unique = 0


### PR DESCRIPTION
This commit series aims at reducing the code needed to load Spec classes from data files.  The initial commits cleanly separates state objects (e.g. `Tech`) from their spec counterpart (e.g. `TechSpec`).  This includes writing an `EventSpec` class.   Secondly, we ensure that state objects are passed their spec counterpart rather than creating the spec itself.  These bits are enablers for the rewrite itself.

The third bit (`Rewrite loading of several spec classes`) moves code around such that each spec declares which data fields they are interested in, how they are interpreted or validated, etc in the class field `spec_data_fields` using `SpecDataField` instances.  These declarations are used by the `GenericSpec` class to create the spec instances from the dictionary from `generic_load`. 

The final commit removes an unused field in the events.dat data file.

