### PR TITLE
Display current cash / CPU flow in the map view

### DIFF
--- a/code/g.py
+++ b/code/g.py
@@ -83,11 +83,10 @@ def quit_game():
     sys.exit()
 
 #Takes a number and adds commas to it to aid in human viewing.
-def add_commas(number):
-    encoding = locale.getlocale()[1] or "UTF-8"
+def add_commas(number, fixed_size=False):
     raw_with_commas = locale.format("%0.2f", number,
                                     grouping=True)
-    locale_test = locale.format("%01.1f", 0.1)
+    locale_test = locale.format("%01.1f", 0.1) if not fixed_size else ''
     if len(locale_test) == 3 and not locale_test[1].isdigit():
         if locale_test[0] == locale.str(0) and locale_test[2] == locale.str(1):
             return raw_with_commas.rstrip(locale_test[0]).rstrip(locale_test[1])
@@ -145,13 +144,13 @@ def to_cpu(amount):
 
 # Instead of having the money display overflow, we should generate a string
 # to represent it if it's more than 999999.
-def to_money(amount):
+def to_money(amount, fixed_size=False):
     abs_amount = abs(amount)
     if abs_amount < 10**6:
-        return add_commas(amount)
+        return add_commas(amount, fixed_size=fixed_size)
 
     prec = 2
-    format = "%.*f%s"
+    format = "%0.*f%s" if fixed_size else "%.*f%s"
     if abs_amount < 10**9: # Millions.
         divisor = 10**6
         #Translators: abbreviation of 'millions'

--- a/code/graphics/dialog.py
+++ b/code/graphics/dialog.py
@@ -381,6 +381,9 @@ class Dialog(text.Text):
         handlers = self.handlers.get(constants.MOUSEMOTION, [])[:]
         self.call_handlers(handlers, event=None)
 
+    def on_close_dialog(self):
+        pass
+
     def call_handlers(self, handlers, event):
         # Feed the event to all the handlers, in priority order.
         for __, handler in handlers:
@@ -390,6 +393,7 @@ class Dialog(text.Text):
                 break # If it's been handled, we leave the rest alone.
             except constants.ExitDialog as e:
                 # Exiting the dialog.
+                self.on_close_dialog()
                 if e.args:
                     # If we're given a return value, we pass it on.
                     return e.args[0]

--- a/code/player.py
+++ b/code/player.py
@@ -87,6 +87,7 @@ class Player(object):
 
         self.log = collections.deque(maxlen=1000)
         self.locations = {loc_id: location.Location(loc_spec) for loc_id, loc_spec in g.locations.items()}
+        self._considered_buyables = []
 
     @property
     def grace_period_cpu(self):
@@ -95,6 +96,15 @@ class Player(object):
     @property
     def base_grace_multiplier(self):
         return self.difficulty.base_grace_multiplier
+
+    @property
+    def considered_buyables(self):
+        return self._considered_buyables
+
+    @considered_buyables.setter
+    def considered_buyables(self, new_value):
+        self._considered_buyables = new_value
+        g.map_screen.needs_rebuild = True
 
     def convert_from(self, old_version):
         if old_version < 4.91: # < r5_pre
@@ -734,6 +744,8 @@ class Player(object):
         available_cpu_pool = cpu_flow
 
         # Base construction.
+        if hasattr(self, '_considered_buyables'):
+            construction.extend(self._considered_buyables)
         for buyable in construction:
             ideal_spending = buyable.cost_left
             # We need to do calculate work twice: Once for figuring out how much CPU

--- a/code/screens/base.py
+++ b/code/screens/base.py
@@ -21,7 +21,7 @@
 
 import pygame
 
-from code import g, item
+from code import g, item, buyable
 from code.graphics import constants, widget, dialog, text, button, slider
 
 state_colors = dict(
@@ -77,8 +77,14 @@ class BuildDialog(dialog.ChoiceDescriptionDialog):
                              background_color="pane_background",
                              align=constants.LEFT, valign=constants.TOP,
                              borders=constants.ALL)
-        
+
+        g.pl.considered_buyables = [buyable.Buyable(self.item, count=1)] if item is not None else []
+
         self.on_description_change()
+
+    def on_close_dialog(self):
+        g.pl.considered_buyables = []
+
 
 class MultipleBuildDialog(dialog.FocusDialog, BuildDialog):
     def __init__(self, parent, *args, **kwargs):
@@ -115,6 +121,11 @@ class MultipleBuildDialog(dialog.FocusDialog, BuildDialog):
         if self.item is not None:
             self.description.text += "\n---\n"
             self.description.text += self.item.get_total_cost_info(self.count_slider.slider_pos)
+            self.description.text += "\n"
+            if self.count_slider.slider_pos > 0:
+                g.pl.considered_buyables = [buyable.Buyable(self.item, count=self.count_slider.slider_pos)]
+            else:
+                g.pl.considered_buyables = []
 
     def on_change(self, description_pane, item):
         space_left = self.parent.base.space_left_for(item)

--- a/code/screens/location.py
+++ b/code/screens/location.py
@@ -270,6 +270,8 @@ class NewBaseDialog(dialog.FocusDialog, dialog.ChoiceDescriptionDialog):
             name = generate_base_name(self.parent.location, base_type)
             self.text_field.text = name
             self.text_field.cursor_pos = len(name)
+        else:
+            g.pl.considered_buyables = []
 
     def show(self):
         self.list = []
@@ -284,7 +286,23 @@ class NewBaseDialog(dialog.FocusDialog, dialog.ChoiceDescriptionDialog):
                 self.list.append(base_type.name)
                 self.key_list.append(base_type)
 
-        return super(NewBaseDialog, self).show()
+        self._new_base_type_selected(self.listbox.list_pos)
+        res = super(NewBaseDialog, self).show()
+        return res
+
+    def handle_update(self, new_item_pos):
+        super(NewBaseDialog, self).handle_update(new_item_pos)
+        if not g.pl or not self.key_list:
+            return
+        self._new_base_type_selected(new_item_pos)
+
+    def _new_base_type_selected(self, new_item_pos):
+        considered_buyables = []
+        if 0 <= new_item_pos < len(self.key_list):
+            base_type = self.key_list[new_item_pos]
+            considered_buyables.append(base.Base('<Undecided>', base_type))
+
+        g.pl.considered_buyables = considered_buyables
 
     def finish(self):
         if 0 <= self.listbox.list_pos < len(self.key_list):
@@ -294,6 +312,9 @@ class NewBaseDialog(dialog.FocusDialog, dialog.ChoiceDescriptionDialog):
                 name = generate_base_name(self.parent.location, type)
 
             raise constants.ExitDialog((name, type))
+
+    def on_close_dialog(self):
+        g.pl.considered_buyables = []
 
 
 # Generates a name for a base, given a particular location.

--- a/code/screens/map.py
+++ b/code/screens/map.py
@@ -289,7 +289,7 @@ class CheatMenuDialog(dialog.SimpleMenuDialog):
         state_prop = []
         state_prop.extend(_properties_from_object('player.difficulty', g.pl.difficulty, difficulty.columns))
         state_prop.extend(_properties_from_object('player', g.pl, [
-            'cash', 'partial_cash', 'labor_bonus', 'job_bonus', 'future_cash',
+            'cash', 'partial_cash', 'labor_bonus', 'job_bonus',
             'last_discovery', 'prev_discovery', 'used_cpu',
         ]))
 
@@ -736,15 +736,13 @@ class MapScreen(dialog.Dialog):
         self.difficulty_display.text = g.strip_hotkey(g.pl.difficulty.name)
         self.time_display.text = _("DAY") + " %04d, %02d:%02d:%02d" % \
               (g.pl.time_day, g.pl.time_hour, g.pl.time_min, g.pl.time_sec)
+
+        cash_flow_1d, cpu_flow_1d = g.pl.compute_future_resource_flow(g.seconds_per_day)
+
         self.cash_display.text = _("CASH")+": %s (%s)" % \
-              (g.to_money(g.pl.cash), g.to_money(g.pl.future_cash()))
+              (g.to_money(g.pl.cash), g.to_money(cash_flow_1d, fixed_size=True))
 
-        cpu_left = g.pl.available_cpus[0]
-        total_cpu = cpu_left + g.pl.sleeping_cpus
-
-        for cpu_assigned in g.pl.cpu_usage.itervalues():
-            cpu_left -= cpu_assigned
-        cpu_pool = cpu_left + g.pl.cpu_usage.get("cpu_pool", 0)
+        total_cpu = g.pl.available_cpus[0] + g.pl.sleeping_cpus
 
         detects_per_day = {group_id: 0 for group_id in g.pl.groups}
         for base in g.all_bases():
@@ -759,7 +757,7 @@ class MapScreen(dialog.Dialog):
 
         self.cpu_display.color = "cpu_normal"
         self.cpu_display.text = _("CPU")+": %s (%s)" % \
-              (g.to_money(total_cpu), g.to_money(cpu_pool))
+              (g.to_money(total_cpu), g.to_money(cpu_flow_1d))
 
         # What we display in the suspicion section depends on whether
         # Advanced Socioanalytics has been researched.  If it has, we


### PR DESCRIPTION
This PR will change the "additional information" values in the cash display and CPU display (i.e. the numbers in brackets).

Previously, we used for:
 * cash: `Current cash - total price of all (active) buyables`
 * CPU: `Size of (effective) CPU pool`

With this change, they are now:'
 * cash: `Expected cash flow within the next hour`.  If it is positive, the player is earning money, if negative, the player is losing money. 
 * CPU: `How many CPUs are idle/missing in the CPU pool`.  If positive, this is the (average) number of CPU units will be performing jobs.  If negative, this the average number of CPU units missing to satisfy the current needs.

Known omissions to the cash view: Income from interest rates and `Arbitrage`.  This is by design to avoid giving the player false hope the hour up to midnight, which will be inflated compared to all other hours.  I think the proper way to fix this omission is to have these income times apply slowly throughout the day like everything else.