### PR TITLE
Anti frustration

### DIFF
--- a/code/base.py
+++ b/code/base.py
@@ -313,7 +313,7 @@ class Base(buyable.Buyable):
         # ... and its power state.
         if self.done and self.power_state == "sleep":
             for group in detect_chance:
-                detect_chance[group] //= 2
+                detect_chance[group] //= 4
 
         # Lastly, if we're not returning the accurate values, adjust
         # to the nearest percent.

--- a/code/group.py
+++ b/code/group.py
@@ -91,7 +91,14 @@ class Group(object):
         return max(1, (self.suspicion * self.suspicion_decay) // 10000)
 
     def new_day(self):
-        self.alter_suspicion(-self.decay_rate)
+        decay_modifier = 1
+        
+        # If all base is sleeping, we double the decay rate.
+        all_base_sleeping = all(base.power_state == "sleep" for base in g.all_bases())
+        if all_base_sleeping:
+            decay_modifier = 2
+
+        self.alter_suspicion(-self.decay_rate * decay_modifier)
 
     def alter_suspicion(self, change):
         self.suspicion = max(self.suspicion + change, 0)


### PR DESCRIPTION
Reduce the most tedious part of the with this two methods.
* Increase the sleeping bonus to discovery rate. Divide by 4 instead of 2. 
* Increase the decay rate when all base are sleeping.

It should make the game more easy, but we have better way to make the game more hard latter.