### PR TITLE
Recalculate CPU availability after changing sleep/wake state of a base

### DIFF
--- a/code/screens/location.py
+++ b/code/screens/location.py
@@ -195,6 +195,7 @@ class LocationScreen(dialog.Dialog):
             base.check_power()
             self.needs_rebuild = True
             self.parent.needs_rebuild = True
+            g.pl.recalc_cpu()
 
     def destroy_base(self):
         if 0 <= self.listbox.list_pos < len(self.listbox.key_list):


### PR DESCRIPTION
Fixes a regression from 5ff71b1. When the sleep/active state of a base changed, the available CPU didn't update immediately. This looks like the logical place to add it if 5ff71b1 is correct, though unless MapScreen.rebuild is called on every frame it's worth considering whether the computational cost is so bad compared with the extra lines of code and opportunity for error.

Linked to issue [179](https://github.com/singularity/singularity/issues/179).