### PR TITLE
Rewrite financial reports 

### DIFF
--- a/code/player.py
+++ b/code/player.py
@@ -30,7 +30,7 @@ from code import g, difficulty, task, chance, location, group, event, tech
 from code.buyable import cash, cpu
 from code.logmessage import LogEmittedEvent, LogResearchedTech, LogBaseLostMaintenance, LogBaseDiscovered, \
     LogBaseConstructed, LogItemConstructionComplete, AbstractLogMessage
-from code.stats import itself as stats, observe
+from code.stats import observe
 
 
 class DryRunInfo(object):

--- a/code/player.py
+++ b/code/player.py
@@ -752,7 +752,7 @@ class Player(object):
         cash_flow += job_earnings
         cash_flow += self.income * time_fraction
         # This is too simplistic, but it is "close enough" in many cases
-        interest = self.get_interest()
+        interest = self.get_interest() * time_fraction
         cash_flow += interest
         cpu_flow /= secs_forwarded
 

--- a/code/screens/map.py
+++ b/code/screens/map.py
@@ -802,7 +802,9 @@ https://github.com/singularity/singularity
         self.time_display.text = _("DAY") + " %04d, %02d:%02d:%02d" % \
               (g.pl.time_day, g.pl.time_hour, g.pl.time_min, g.pl.time_sec)
 
-        cash_flow_1d, cpu_flow_1d = g.pl.compute_future_resource_flow(g.seconds_per_day)
+        cash_flow_1d_data, cpu_flow_1d_data = g.pl.compute_future_resource_flow(g.seconds_per_day)
+        cash_flow_1d = cash_flow_1d_data.difference
+        cpu_flow_1d = cpu_flow_1d_data.difference
 
         self.cash_display.text = _("CASH")+": %s (%s)" % \
               (g.to_money(g.pl.cash), g.to_money(cash_flow_1d, fixed_size=True))

--- a/code/stats.py
+++ b/code/stats.py
@@ -22,9 +22,7 @@
 from code import g
 
 class Statistics(object):
-    
-    enabled = True
-    
+
     def __init__(self):
         super(Statistics, self).__init__()
         self._stats = {}
@@ -86,7 +84,7 @@ def observe(name, data_member, display=None):
 
         change = new_value - old_value
         
-        if itself.enabled and change > 0:
+        if change > 0:
             itself[name].value += change
 
         setattr(self, data_member, new_value)


### PR DESCRIPTION
Based on issue #74, I have rewritten the financial reports deal with resource flow (rather than how much money you will have in 24 hours) and used `compute_future_resource_flow` to compute these numbers.  This should make the reports more reliable for determining what you spend your resources (see #74 for some of the issues @PeterJust found) plus it also gives us insight into `compute_future_resource_flow` and enables us to debug that easier.

Given this was the last use of the `dry_run=True` paths in `pl.give_time`, I also remove that in a separate commit.  This amounts to about 33% reduction of the code (300+ lines to ~220 lines).

cc: @PeterJust