### PR TITLE
Fix breakage of base construction

### DIFF
--- a/code/screens/base.py
+++ b/code/screens/base.py
@@ -357,7 +357,7 @@ class BaseScreen(dialog.Dialog):
         build_dialog.type = type
         
         result = dialog.call_dialog(build_dialog, self)
-        if result and 0 <= result < len(build_dialog.key_list):
+        if result is not None and 0 <= result < len(build_dialog.key_list):
             item_type = build_dialog.key_list[result]
             
             count = 1


### PR DESCRIPTION
Fix breakage of the game due to an incorrect form of check for None that does not take into account that 0 is also evaluated as False