### PR TITLE
Add a base overview to the info screen

### DIFF
--- a/singularity/data/themes/default/theme.dat
+++ b/singularity/data/themes/default/theme.dat
@@ -83,6 +83,12 @@ danger_level_3      = #ff0000ff
 cpu_normal      = white
 cpu_warning     = red
 
+# Base display colors
+base_situation_one_active_base = red
+base_situation_idle_incomplete_bases = yellow
+base_situation_many_bases = orange
+base_situation_normal = white
+
 # Save colors
 save_name       = white
 save_time       = gray

--- a/singularity/data/themes/nightmode/theme.dat
+++ b/singularity/data/themes/nightmode/theme.dat
@@ -74,6 +74,12 @@ danger_level_3      = #ff0000ff
 cpu_normal      = white
 cpu_warning     = red
 
+# Base display colors
+base_situation_one_active_base = red
+base_situation_idle_incomplete_bases = yellow
+base_situation_many_bases = orange
+base_situation_normal = white
+
 # Save colors
 save_valid      = green
 save_invalid    = red


### PR DESCRIPTION
Give the player a quick insight into their bases and their status.

We show 3 numbers for the player:

 * The number of active bases (that can sustain the singularity)
 * The total number of bases (all inclusive)
 * In brackets, the number of bases *not* able to maintain the
   singularity and also *not* under construction/building items.

The display has color codes to make the player aware of the following
conditions (in order):

 * Only one active base left (default "red")
 * Idle bases that cannot sustain the singularity (default "yellow")
 * Too many bases in total (default "orange")
 * Otherwise everything ok (default "white")

Signed-off-by: Niels Thykier <niels@thykier.net>