### PR TITLE
Make (some) text sizes configurable and reduce the default size

### DIFF
--- a/singularity/__init__.py
+++ b/singularity/__init__.py
@@ -203,6 +203,19 @@ def main():
             except Exception:
                 pass # don't be picky (for now...)
 
+        if prefs.has_section("Textsizes"):
+            for key in prefs.options('Textsizes'):
+                if key in prefs.defaults():  # Filter default key
+                    continue
+
+                if key not in gg.configured_text_sizes:  # Ignore unknown text-size definitions
+                    continue
+
+                try:
+                    gg.configured_text_sizes[key] = prefs.getint("Textsizes", key)
+                except Exception:
+                    pass  # Ignore
+
 
     #Handle the program arguments.
     desc = """Endgame: Singularity is a simulation of a true AI.

--- a/singularity/code/graphics/button.py
+++ b/singularity/code/graphics/button.py
@@ -114,6 +114,7 @@ class Button(text.SelectableText, HotkeyText):
 
         self.priority = priority
 
+        kwargs.setdefault('text_size', 'button')
         super(Button, self).__init__(parent, pos, size, **kwargs)
 
         self.base_font = base_font or "special"

--- a/singularity/code/graphics/g.py
+++ b/singularity/code/graphics/g.py
@@ -58,6 +58,17 @@ resolutions = [
     (1920,1080),
 ]
 
+
+# Configurable by the user
+configured_text_sizes = {
+    'default': 20,
+    'button': 36,
+    'suspicion_bar': 32,
+    'time_display': 24,
+    'resource_display': 24,
+    'report_content': 20,
+}
+
 fullscreen = False
 
 #colors:
@@ -206,3 +217,10 @@ def resolve_font_alias(font):
         return resolve_color_alias(fonts[font])
     else:
         return font
+
+
+def resolve_text_size(text_size):
+    if isinstance(text_size, basestring):
+        return resolve_text_size(configured_text_sizes[text_size])
+    else:
+        return text_size

--- a/singularity/code/graphics/text.py
+++ b/singularity/code/graphics/text.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 
 import pygame
 
+from singularity.code.pycompat import *
 from singularity.code.graphics import g, widget, constants
 
 
@@ -187,9 +188,11 @@ def print_line(surface, xy, font, chunks, styles):
         # Adjust the starting position.
         xy[0] += size[0]
 
+
 def resize_redraw(self):
     self.needs_resize = True
     self.needs_redraw = True
+
 
 class Text(widget.BorderedWidget):
     text = widget.call_on_change("_text", resize_redraw)
@@ -206,10 +209,13 @@ class Text(widget.BorderedWidget):
     base_font = widget.auto_reconfig("_base_font", "resolved", g.resolve_font_alias)
     resolved_base_font = widget.call_on_change("_resolved_base_font", resize_redraw)
 
+    text_size = widget.auto_reconfig("_text_size", "resolved", g.resolve_text_size)
+    resolved_text_size = widget.causes_redraw("_resolved_text_size")
+
     def __init__(self, parent, pos, size=(0, .05), anchor=constants.TOP_LEFT,
                  text=None, base_font=None, shrink_factor=0.875,
                  color=None, align=constants.CENTER, valign=constants.MID,
-                 underline=-1, wrap=True, bold=False, text_size=36, **kwargs):
+                 underline=-1, wrap=True, bold=False, text_size="default", **kwargs):
         kwargs.setdefault("background_color", "text_background")
         kwargs.setdefault("border_color", "text_border")
         super(Text, self).__init__(parent, pos, size, anchor, **kwargs)
@@ -226,7 +232,7 @@ class Text(widget.BorderedWidget):
         self.text_size = text_size
 
     max_size = property(lambda self: min(len(self.resolved_base_font)-1,
-                                         convert_font_size(self.text_size)))
+                                         convert_font_size(self._resolved_text_size)))
     font = property(lambda self: self._font)
 
     def pick_font(self, dimensions):

--- a/singularity/code/screens/map.py
+++ b/singularity/code/screens/map.py
@@ -469,6 +469,7 @@ class MapScreen(dialog.Dialog):
         self.suspicion_bar = \
             text.FastStyledText(self, (0,.92), (1, .04), base_font="special",
                                 wrap=False,
+                                text_size="suspicion_bar",
                                 background_color="pane_background_empty",
                                 border_color="pane_background",
                                 borders=constants.ALL, align=constants.LEFT)
@@ -477,6 +478,7 @@ class MapScreen(dialog.Dialog):
         self.danger_bar = \
             text.FastStyledText(self, (0,.96), (1, .04), base_font="special",
                                 wrap=False,
+                                text_size="suspicion_bar",
                                 background_color="pane_background_empty",
                                 border_color="pane_background",
                                 borders=constants.ALL, align=constants.LEFT)
@@ -527,6 +529,7 @@ class MapScreen(dialog.Dialog):
             text.FastText(self, (0, 0.05), (0.13, 0.04),
                           wrap=False,
                           base_font="special",
+                          text_size=36,
                           background_color="pane_background_empty",
                           border_color="pane_background")
 
@@ -534,6 +537,7 @@ class MapScreen(dialog.Dialog):
                                           wrap=False,
                                           text=_("DAY")+" 0000, 00:00:00",
                                           base_font="special",
+                                          text_size="time_display",
                                           background_color="pane_background_empty",
                                           border_color="pane_background",
                                           borders=constants.ALL)
@@ -573,6 +577,7 @@ class MapScreen(dialog.Dialog):
                           wrap=False,
                           base_font="special", shrink_factor = .7,
                           borders=constants.ALL,
+                          text_size="resource_display",
                           background_color="pane_background_empty",
                           border_color="pane_background")
 
@@ -580,8 +585,8 @@ class MapScreen(dialog.Dialog):
             text.FastText(self.info_window, (0,-.5), (-1, -.5),
                           wrap=False,
                           base_font="special", shrink_factor=.7,
-                          borders=
-                           (constants.LEFT, constants.RIGHT, constants.BOTTOM),
+                          borders=(constants.LEFT, constants.RIGHT, constants.BOTTOM),
+                          text_size="resource_display",
                           background_color="pane_background_empty",
                           border_color="pane_background")
 

--- a/singularity/code/screens/options.py
+++ b/singularity/code/screens/options.py
@@ -588,6 +588,7 @@ def set_language_properly(language):
     dialog.Dialog.top.needs_rebuild = True
     dialog.Dialog.top.needs_redraw = True
 
+
 def save_options():
     # Build a ConfigParser for writing the various preferences out.
     prefs = SafeConfigParser()
@@ -609,11 +610,15 @@ def save_options():
     for warn_id, warn in warning.warnings.items():
         prefs.set("Warning", warn_id, str(bool(warn.active)))
 
+    prefs.add_section("Textsizes")
+    for text_size_id, text_size in gg.configured_text_sizes.items():
+        prefs.set("Textsizes", text_size_id, str(text_size))
+
     # Actually write the preferences out.
     save_loc = dirs.get_writable_file_in_dirs("prefs.dat", "pref")
-    savefile = open(save_loc, 'w')
-    prefs.write(savefile)
-    savefile.close()
+    with open(save_loc, 'w') as savefile:
+        prefs.write(savefile)
+
 
 def restart():
     """ Restarts the game with original command line arguments. Those may over-

--- a/singularity/code/screens/report.py
+++ b/singularity/code/screens/report.py
@@ -133,7 +133,7 @@ class ReportScreen(dialog.Dialog):
                 m(cpu_info.maintenance_needed), m(cpu_info.construction_needed),
                 m(cpu_info.difference))
 
-        size = 20
+        size = 'report_content'
         text.Text(self.money_report_pane, (0,-0.15), (-0.10,-0.85), text=financial_pluses, text_size=size,
                   background_color="clear",
                   align=constants.CENTER, valign=constants.TOP)


### PR DESCRIPTION
I believe this will fix #200.  With this patch, the story mode dialogs (among other) uses a consist font-size for me.

@evilmrhenry / @Xenega: If you have time, it would be great if you could review this change.  Note I have deliberately skipped the Options widget to control text-sizes via the Options menu for now. If we merge this, I will file an issue to follow up on that later.

