### PR TITLE
WIP: Add auto-build feature (#146)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -12,6 +12,10 @@ USER-VISIBLE CHANGES:
   (Reload theme is now `F6`).
 - Save games are now ordered by time (most recent first) rather
   than name. This makes it easier to find the latest savegame.
+- There is now an "Auto-build items" button in the base overview.
+  It will propose building all the highest value items in each
+  empty base slot (provided there is anything buildable for
+  that base).
 
 V1.00 (2020.07.02):
 

--- a/singularity/code/global_hotkeys.py
+++ b/singularity/code/global_hotkeys.py
@@ -21,7 +21,7 @@ _MODIFIERLESS_HOT_KEYS = frozenset(
 )
 
 
-@dataclasses.dataclass(slots=True, frozen=True)
+@dataclasses.dataclass
 class GlobalHotKey:
     modifiers: int
     key: int


### PR DESCRIPTION
Here is a PoC on creating an auto-build feature as requested in #146.  It currently only builds the "best available items on *empty* base slots".  This enables the player to pre-select some choices and have the auto-builder deal with the rest.

Please review this with the following questions in mind:

 * Does the basic functionality work? (i.e. can you make it crash or enable you to build items on bases where you should not)
 * Does the visible layout seem good? If not, what do you want to change?
 * Does the feature work as you would expect it?  If not, what did you find surprising or what could have been presented better? (e.g. should we rename the button text)
 * Would you use the feature as it is? 

@sunfall - there is a single dialog at https://github.com/singularity/singularity/commit/e8c48a432336bbcf5dc442272ec679befffeed18#diff-2f39020070b171a3b8a77ef5549bd1a8R359 which could do with a textual review.
