### PR TITLE
Make location and base screens wider to fit more text

### DIFF
--- a/singularity/code/screens/base.py
+++ b/singularity/code/screens/base.py
@@ -76,7 +76,7 @@ class BuildDialog(dialog.ChoiceDescriptionDialog):
 
     def on_change(self, description_pane, item):
         self.item = item
-        
+
         self.description = text.Text(self.description_pane, (0, 0), (-1, -1), text="",
                              background_color="pane_background",
                              align=constants.LEFT, valign=constants.TOP,
@@ -151,14 +151,14 @@ class MultipleBuildDialog(dialog.FocusDialog, BuildDialog):
 
     def on_change(self, description_pane, item):
         space_left = self.parent.base.space_left_for(item)
-        
+
         self.count_slider.slider_size = space_left // 10 + 1
         self.count_slider.slider_max = space_left
 
         self.count_slider.slider_pos = 0
         if (space_left > 0):
             self.count_slider.slider_pos = 1
-            
+
         super(MultipleBuildDialog, self).on_change(description_pane, item)
 
     def on_field_change(self, value):
@@ -184,14 +184,14 @@ class MultipleBuildDialog(dialog.FocusDialog, BuildDialog):
     def on_slider_change(self, value):
         if (not hasattr(self, "count_field") or not hasattr(self, "count_slider")):
             return # Not initialized
-        
+
         self.count_field.text = str(self.count_slider.slider_pos)
         self.on_description_change()
 
 
 class ItemPane(widget.BorderedWidget):
     item_type = widget.causes_rebuild("_item_type")
-    def __init__(self, parent, pos, size=(.48, .06), anchor=constants.TOP_LEFT,
+    def __init__(self, parent, pos, size=(.58, .06), anchor=constants.TOP_LEFT,
                  item_type=None, **kwargs):
 
         kwargs.setdefault("background_color", "pane_background")
@@ -203,20 +203,20 @@ class ItemPane(widget.BorderedWidget):
 
         self.item_type = item_type
 
-        self.name_panel = text.Text(self, (0,0), (.35, .03),
+        self.name_panel = text.Text(self, (0,0), (.45, .03),
                                     anchor=constants.TOP_LEFT,
                                     align=constants.LEFT,
                                     background_color=self.background_color,
                                     bold=True)
 
-        self.build_panel = text.Text(self, (0,.03), (.35, .03),
+        self.build_panel = text.Text(self, (0,.03), (.45, .03),
                                      anchor=constants.TOP_LEFT,
                                      align=constants.LEFT,
                                      background_color=self.background_color,
                                      text="", bold=True)
 
         self.change_button = button.FunctionButton(
-            self, (.36,.01), (.12, .04),
+            self, (.415,.01), (.16, .04),
             anchor=constants.TOP_LEFT,
             force_underline=len(_("CHANGE")) + 2,
             autohotkey=True,
@@ -233,7 +233,7 @@ class BaseScreen(dialog.Dialog):
     base = widget.causes_rebuild("_base")
     def __init__(self, *args, **kwargs):
         if len(args) < 3:
-            kwargs.setdefault("size", (.75, .70))
+            kwargs.setdefault("size", (.90, .70))
         base = kwargs.pop("base", None)
         super(BaseScreen, self).__init__(*args, **kwargs)
 
@@ -283,7 +283,7 @@ class BaseScreen(dialog.Dialog):
                                     anchor=constants.BOTTOM_CENTER,
                                     )
 
-        self.info_frame = text.Text(self, (-1, .09), (.21, .53),
+        self.info_frame = text.Text(self, (-1, .09), (.26, .53),
                                       anchor=constants.TOP_RIGHT,
                                       background_color="pane_background",
                                       borders=constants.ALL,
@@ -292,7 +292,7 @@ class BaseScreen(dialog.Dialog):
                                       valign=constants.TOP)
 
         self.contents_frame = \
-            widget.BorderedWidget(self, (0, .09), (.50, .53),
+            widget.BorderedWidget(self, (0, .09), (.60, .53),
                                   anchor=constants.TOP_LEFT,
                                   background_color="pane_background",
                                   borders=range(6))
@@ -308,7 +308,7 @@ class BaseScreen(dialog.Dialog):
     def set_current(self, type, item_type, count):
         if type.id == "cpu":
             space_left = self.base.space_left_for(item_type)
-            
+
             try:
                 count = int(count)
             except ValueError:
@@ -320,7 +320,7 @@ class BaseScreen(dialog.Dialog):
                 dialog.call_dialog(md, self)
                 md.parent = None
                 return
-            
+
             if count > space_left or count <= 0 or space_left == 0:
                 if space_left > 0:
                     msg = _("Please choose an integer between 1 and %(limit)s.") % {"limit": space_left}
@@ -334,7 +334,7 @@ class BaseScreen(dialog.Dialog):
                 dialog.call_dialog(md, self)
                 md.parent = None
                 return
-            
+
             # If there are any existing CPUs of this type, warn that they will
             # be taken offline until construction finishes.
             cpu_added = self.base.cpus is not None \
@@ -384,17 +384,17 @@ class BaseScreen(dialog.Dialog):
             build_dialog = self.multiple_build_dialog
         else:
             build_dialog = self.build_dialog
-        
+
         build_dialog.type = type
-        
+
         result = dialog.call_dialog(build_dialog, self)
         if result is not None and 0 <= result < len(build_dialog.key_list):
             item_type = build_dialog.key_list[result]
-            
+
             count = 1
             if (type.id == "cpu"):
                 count = build_dialog.count
-            
+
             self.set_current(type, item_type, count)
             self.needs_rebuild = True
             self.parent.parent.needs_rebuild = True
@@ -464,7 +464,7 @@ class BaseScreen(dialog.Dialog):
         info_text += _("Maintenance:") + "\n"
         info_text += self.base.spec.describe_maintenance(self.base.maintenance)
         info_text += "\n"
-    
+
         # Detection chance display.
         info_text += self.base.get_detect_info()
 

--- a/singularity/code/screens/location.py
+++ b/singularity/code/screens/location.py
@@ -91,7 +91,7 @@ class LocationScreen(dialog.Dialog):
                                   anchor=constants.TOP_CENTER,
                                   autohotkey=True,
                                   function=self.destroy_base)
-        self.back_button = button.ExitDialogButton(self, (-1, -.9), (-.3, -.09),
+        self.back_button = button.ExitDialogButton(self, (-1, -.91), (-.3, -.09),
                                                    autotranslate=True,
                                                    text=N_("&BACK"),
                                                    anchor=constants.TOP_RIGHT,

--- a/singularity/code/screens/location.py
+++ b/singularity/code/screens/location.py
@@ -35,7 +35,7 @@ class LocationScreen(dialog.Dialog):
         super(LocationScreen, self).__init__(*args, **kwargs)
         self.pos = (-.5, -.5)
         self.anchor = constants.MID_CENTER
-        self.size = (.75, .70)
+        self.size = (.90, .70)
 
         self.name_display = text.Text(self, (0,0), (-1, -.08),
                                       anchor=constants.TOP_LEFT,
@@ -43,7 +43,7 @@ class LocationScreen(dialog.Dialog):
                                       border_color="pane_background",
                                       background_color="pane_background_empty",
                                       shrink_factor=1, bold=True)
-        self.modifier_display = text.Text(self, (-.75, -.01), (-.25, -.06),
+        self.modifier_display = text.Text(self, (-.65, -.01), (-.35, -.06),
                                           anchor=constants.TOP_LEFT,
                                           background_color="clear")
 
@@ -126,13 +126,13 @@ class LocationScreen(dialog.Dialog):
         canvas.base_type      = text.Text(canvas, (-.27,-.05), (-.23, -.99),
                                           align=constants.LEFT,
                                           background_color="clear")
-        canvas.base_cpu       = text.Text(canvas, (-.50,-.05), (-.13, -.99),
+        canvas.base_cpu       = text.Text(canvas, (-.48,-.05), (-.13, -.99),
                                           align=constants.LEFT,
                                           background_color="clear")
-        canvas.status_display = text.Text(canvas, (-.63,-.05), (-.35, -.99),
+        canvas.status_display = text.Text(canvas, (-.59,-.05), (-.36, -.99),
                                           align=constants.LEFT,
                                           background_color="clear")
-        canvas.power_display  = text.Text(canvas, (-.93,-.05), (-.07, -.99),
+        canvas.power_display  = text.Text(canvas, (-.90,-.05), (-.10, -.99),
                                           background_color="clear")
 
 


### PR DESCRIPTION
Fix text overlap and too tiny text on locations screen in gd locale by making it wider. Make base screen wider to match.

Before:

![location_overflow](https://user-images.githubusercontent.com/4095570/82898637-9178c580-9f51-11ea-9f8f-07e2a931fc16.png)

After:

![location-new](https://user-images.githubusercontent.com/4095570/82898660-99386a00-9f51-11ea-94d6-d3f49442b81e.png)

And the wider base screen:

![base-new](https://user-images.githubusercontent.com/4095570/82898682-a35a6880-9f51-11ea-9f3a-f9530cbb7b9d.png)

