### PR TITLE
Make report and stats screens wider

### DIFF
--- a/singularity/code/screens/report.py
+++ b/singularity/code/screens/report.py
@@ -48,9 +48,9 @@ class ReportScreen(dialog.Dialog):
         self.add_key_handler(pygame.K_ESCAPE, self.back_button.activate_with_sound)
 
 
-        self.money_report_pane = widget.BorderedWidget(self, (0, .08), (-.45, -.72),
+        self.money_report_pane = widget.BorderedWidget(self, (0, .08), (-.50, -.72),
                                                        anchor=constants.TOP_LEFT)
-        self.cpu_report_pane = widget.BorderedWidget(self, (-1, .08), (-.45, -.72),
+        self.cpu_report_pane = widget.BorderedWidget(self, (-1, .08), (-.50, -.72),
                                                      anchor=constants.TOP_RIGHT)
 
         self.format_button_midnight = FormatButton(self, (-.5, 0), (-.15, -.08),
@@ -104,7 +104,7 @@ class ReportScreen(dialog.Dialog):
         financial_report += _("Interest (%s):") % \
                              (g.to_percent(g.pl.interest_rate))+"\n"
         financial_report += _("Income:")+"\n"
-        
+
         if (self.midnight_stop):
             financial_report += _("Money flow until Midnight:")+"\n"
         else:

--- a/singularity/code/screens/stat.py
+++ b/singularity/code/screens/stat.py
@@ -25,8 +25,8 @@ from singularity.code.graphics import dialog, constants, listbox, text
 
 
 class StatScreen(dialog.ChoiceDialog):
-    
-    def __init__(self, parent, pos=(.5, .1), size=(.43, .63), *args, **kwargs):
+
+    def __init__(self, parent, pos=(.5, .1), size=(.53, .63), *args, **kwargs):
         super(StatScreen, self).__init__(parent, pos, size, *args, **kwargs)
 
         self.yes_button.parent = None
@@ -45,7 +45,7 @@ class StatScreen(dialog.ChoiceDialog):
                                      anchor=constants.TOP_LEFT,
                                      align=constants.LEFT,
                                      background_color="clear")
-        canvas.stat_value = text.Text(canvas, (-.99, -.01), (-.21, -1.),
+        canvas.stat_value = text.Text(canvas, (-.99, -.01), (-.26, -1.),
                                       anchor=constants.TOP_RIGHT,
                                       align=constants.RIGHT,
                                       background_color="clear")
@@ -56,15 +56,15 @@ class StatScreen(dialog.ChoiceDialog):
 
             canvas.stat_name.text = item[1]
             canvas.stat_value.text = stat.display_value()
-        
+
     def show(self):
         # FIXME: Remove the needs of this array.
         self.list = [
             ("cash_earned" , _("Cash Earned")),
-            ("cpu_used"    , _("Cpu Used")), 
-            ("tech_created", _("Tech Created")), 
-            ("base_created", _("Base Created")), 
-            ("item_created", _("Item Created")), 
+            ("cpu_used"    , _("Cpu Used")),
+            ("tech_created", _("Tech Created")),
+            ("base_created", _("Base Created")),
+            ("item_created", _("Item Created")),
         ]
 
         return super(StatScreen, self).show()


### PR DESCRIPTION
* Fix text overlap on reports screen
* Large numbers on stats screen towards the end game become small, so I made that a bit wider too.

Screenshot of the overlap (gd locale):

![reports-overlap](https://user-images.githubusercontent.com/4095570/82921660-897c4e00-9f70-11ea-846a-0120d77b1334.png)

Screenshot with this branch:

![reports-fixed](https://user-images.githubusercontent.com/4095570/82921684-9305b600-9f70-11ea-9194-5b7a16290b56.png)
