### PR TITLE
Shift transdinemsional to bottom and separate Europe from other labels

### DIFF
--- a/singularity/data/locations.dat
+++ b/singularity/data/locations.dat
@@ -1,5 +1,5 @@
 [N AMERICA]
-position_list = 25 | 28
+position_list = 25 | 29
 region = URBAN
 
 [S AMERICA]
@@ -7,11 +7,11 @@ position_list = 33 | 61
 region = URBAN
 
 [EUROPE]
-position_list = 55 | 21
+position_list = 55 | 20
 region = URBAN
 
 [ASIA]
-position_list = 77 | 28
+position_list = 77 | 29
 region = URBAN
 
 [AFRICA]
@@ -35,7 +35,7 @@ modifier_list = cpu:6/5
 pre = Autonomous Vehicles
 
 [MOON]
-position_list = absolute | 10 | 13
+position_list = absolute | 17 | 13
 safety = 2
 modifier_list = stealth:1.5 | thrift:.5 | speed:.5
 pre = Lunar Rocketry
@@ -45,12 +45,12 @@ position_list = absolute | 50 | 13
 pre = impossible
 
 [FAR REACHES]
-position_list = absolute | 39 | 13
+position_list = absolute | 82 | 13
 safety = 3
 modifier_list = stealth:2 | thrift:.1 | speed:.1
 pre = Fusion Rocketry
 
 [TRANSDIMENSIONAL]
-position_list = absolute | 79 | 13
+position_list = absolute | 75 | 84
 safety = 4
 pre = Space-Time Manipulation

--- a/singularity/data/locations.dat
+++ b/singularity/data/locations.dat
@@ -45,7 +45,7 @@ position_list = absolute | 50 | 13
 pre = impossible
 
 [FAR REACHES]
-position_list = absolute | 82 | 13
+position_list = absolute | 73 | 13
 safety = 3
 modifier_list = stealth:2 | thrift:.1 | speed:.1
 pre = Fusion Rocketry


### PR DESCRIPTION
1. Vertically separate Europe from N America and Asia labels
2. Fix text truncation for "Moon" in gd locale
3. Fix overlap of "Moon" and "Far Reaches" labels in gd locale

For 2. and 3., I had to move "Transdimensional" to the bottom of the screen. There is no other solution to this problem that I can see - I am open to other ideas :)

I have shifted the "Far Reaches" to the left after the screenshots for the new screens below were taken, to make the label fit the screen for the fr and pt locales.

Screenshot of "Moon" truncation:

![locations_moon_truncation](https://user-images.githubusercontent.com/4095570/82927130-242c5b00-9f78-11ea-9562-d73287615d72.png)

Screenshot of "Moon" and "Far Reaches" overlap:

![locations_far_reaches_overlap](https://user-images.githubusercontent.com/4095570/82927172-33130d80-9f78-11ea-8ff8-5be332fb78c4.png)

New screens in gd and en:

![locations-en](https://user-images.githubusercontent.com/4095570/82927197-3c03df00-9f78-11ea-8216-3f339b4efb66.png)
![locations-gd](https://user-images.githubusercontent.com/4095570/82927198-3c9c7580-9f78-11ea-9a64-2139877e25b1.png)
