### PR TITLE
Theme usabulity tweaks

### DIFF
--- a/singularity/code/graphics/dialog.py
+++ b/singularity/code/graphics/dialog.py
@@ -614,6 +614,7 @@ class TextEntryDialog(TextDialog, FocusDialog):
 
         self.text_field = text.EditableText(self, (-.05, -.25), (-.90, -.25),
                                             borders=constants.ALL,
+                                            background_color="text_entry_background",
                                             base_font="normal")
 
         self.ok_button = button.FunctionButton(self, (-.14, -.65), (-.30, -.25),

--- a/singularity/code/screens/location.py
+++ b/singularity/code/screens/location.py
@@ -277,6 +277,7 @@ class NewBaseDialog(dialog.FocusDialog, dialog.ChoiceDescriptionDialog):
         self.text_field = text.EditableText(self, (-.26, -.87), (-.73, -.1),
                                             anchor=constants.BOTTOM_LEFT,
                                             borders=constants.ALL,
+                                            background_color="text_entry_background",
                                             base_font="normal")
 
         self.desc_func = self.on_change

--- a/singularity/code/screens/savegame.py
+++ b/singularity/code/screens/savegame.py
@@ -55,6 +55,7 @@ class SavegameScreen(dialog.ChoiceDialog):
                                                   borders=constants.ALL,
                                                   anchor=constants.TOP_LEFT,
                                                   update_func=self._search_for_savegame,
+                                                  background_color="text_entry_background",
                                                   base_font="normal")
 
         self.delete_button = button.FunctionButton(self, (-.50, -.99), (-.3, -.1),
@@ -128,7 +129,7 @@ class SavegameScreen(dialog.ChoiceDialog):
                                              anchor=constants.BOTTOM_LEFT,
                                              align=constants.LEFT,
                                              color="save_time",
-                                             background_color="clear")                               
+                                             background_color="clear")
         item.version_display     = text.Text(item, (-.99, -.01), (-.45, -.60),
                                              anchor=constants.TOP_RIGHT,
                                              align=constants.RIGHT,
@@ -186,7 +187,7 @@ class SavegameScreen(dialog.ChoiceDialog):
 
                 dif = save.headers.get("difficulty", "")
                 dif_str = g.strip_hotkey(getattr(difficulty.difficulties.get(dif, None), "name", ""))
-                
+
                 item.time_display.text = tm_str + " | " + gtm_str if tm_str else gtm_str
                 item.difficulty_display.text = dif_str
 

--- a/singularity/data/themes/default/theme.dat
+++ b/singularity/data/themes/default/theme.dat
@@ -18,6 +18,7 @@ gray            = #808080ff
 dark_red        = #800000ff
 dark_green      = #008000ff
 dark_blue       = #000080ff
+darker_blue1    = #000050ff
 darker_blue     = #000032ff
 light_red       = #ff3232ff
 light_green     = #32ff32ff
@@ -42,6 +43,7 @@ pane_background_empty    = black
 
 # Dialog colors
 text_dialog_background   = dark_blue
+text_entry_background    = darker_blue1
 text_dialog_border       = white
 
 # Widget colors
@@ -63,7 +65,7 @@ progress_background_progress   = blue
 progress_border                = white
 
 # Slider colors dark_blue light_blue white
-slider_background = dark_blue 
+slider_background = dark_blue
 slider_background_slider = light_blue
 slider_border = white
 

--- a/singularity/data/themes/nightmode/theme.dat
+++ b/singularity/data/themes/nightmode/theme.dat
@@ -13,6 +13,7 @@ orange          = #ff8000ff
 gray            = #808080ff
 dark_gray       = #404040ff
 dark_red        = #800000ff
+darker_red      = #280000ff
 dark_green      = #008000ff
 dark_blue       = #000080ff
 darker_blue     = #000032ff
@@ -26,7 +27,7 @@ main_menu_background     = black
 about_dialog_background  = black
 map_background           = black
 options_background       = black
-singularity_title        = dark_red
+singularity_title        = gray
 hidden_state_menu        = black
 
 # Pane colors
@@ -35,6 +36,7 @@ pane_background_empty    = black
 
 # Dialog colors
 text_dialog_background   = black
+text_entry_background    = darker_red
 text_dialog_border       = dark_red
 
 # Widget colors


### PR DESCRIPTION
- Give text entry fields slightly darker background
- Make game title visible in dark mode

I found it hard to understand which text fields are for display only, and which are editable. So, I made their background a bit darker. I hope I haven't missed any.

Screenshots:

![textentry](https://user-images.githubusercontent.com/4095570/83034993-cad43280-a030-11ea-95c1-2089b5450481.png)
![textentry2](https://user-images.githubusercontent.com/4095570/83035003-cdcf2300-a030-11ea-8758-9373e67c00bf.png)
![nightmode2](https://user-images.githubusercontent.com/4095570/83035008-d0ca1380-a030-11ea-8460-c8a98318d059.png)
![nightmode1](https://user-images.githubusercontent.com/4095570/83035012-d3c50400-a030-11ea-9ff9-3934abcd076d.png)
