### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/devel/data_files.rst
+++ b/docs/devel/data_files.rst
@@ -9,7 +9,7 @@ remember:
    (e.g. ``data/bases.dat`` describes all types of bases)
 
  * ``data/X_str.dat`` contains English text for each of the data set
-   in ``data/X.dat`` (e.g. ``data/bases_str.dat`` contans the English
+   in ``data/X.dat`` (e.g. ``data/bases_str.dat`` contains the English
    names and descriptions for the bases).
 
  * ``i18n/lang_ll_LL/data_str.po`` contains the translations of the
@@ -74,8 +74,8 @@ The Singularity game special cases all fields that end with ``_list``.
 These read as pipe-separated (i.e. ``|``) lists versions of the field
 (after removing ``_list``).  A very common usage is when item has more
 than one prerequisites.  Prerequisites are normally written in the field
-``pre``. However, if the item has more than one preequisites then they
-are listed in ``pre_list`` with ``|`` seperating each entry.
+``pre``. However, if the item has more than one prerequisites then they
+are listed in ``pre_list`` with ``|`` separating each entry.
 
 As an example, consider the previous example again::
 

--- a/singularity/code/g.py
+++ b/singularity/code/g.py
@@ -332,7 +332,7 @@ def hotkey(string):
     text: the string stripped of all '&'s that precedes a valid hotkey char, if
           any. All '&&' are also replaced for '&'. Other '&'s, if any, are kept
 
-    Examples: (showing only key, pos, orig, text as a touple for clarity)
+    Examples: (showing only key, pos, orig, text as a tuple for clarity)
     hotkey(E&XIT)           => ('x', 1, 2, 'EXIT')
     hotkey(&Play D&&D)      => ('p', 0, 1, 'Play D&D')
     hotkey(Romeo & &Juliet) => ('j', 8, 9, 'Romeo & Juliet')

--- a/singularity/code/graphics/widget.py
+++ b/singularity/code/graphics/widget.py
@@ -474,7 +474,7 @@ class Widget(object):
         if redrew_self:
             # If we redrew this widget, we tell our parent to consider it
             # instead.  The parent will recurse down to any descendants if
-            # needed, and redraw already propogated down to them.
+            # needed, and redraw already propagated down to them.
             check_mask = [self]
 
         if update_full_rect:

--- a/singularity/code/polib.py
+++ b/singularity/code/polib.py
@@ -227,7 +227,7 @@ def unescape(st):
 class _BaseFile(list):
     """
     Common base class for the :class:`~polib.POFile` and :class:`~polib.MOFile`
-    classes. This class should **not** be instanciated directly.
+    classes. This class should **not** be instantiated directly.
     """
 
     def __init__(self, *args, **kwargs):
@@ -727,7 +727,7 @@ class MOFile(_BaseFile):
 class _BaseEntry(object):
     """
     Base class for :class:`~polib.POEntry` and :class:`~polib.MOEntry` classes.
-    This class should **not** be instanciated directly.
+    This class should **not** be instantiated directly.
     """
 
     def __init__(self, *args, **kwargs):

--- a/singularity/code/pycompat.py
+++ b/singularity/code/pycompat.py
@@ -1,4 +1,4 @@
-# A minimal python compatiability layer to support the bare minimum requirements
+# A minimal python compatibility layer to support the bare minimum requirements
 # that singularity need to be python2 and python3 compatible at the same time.
 #
 # We could use the six module for this, but it seems like overkill given how


### PR DESCRIPTION
There are small typos in:
- docs/devel/data_files.rst
- singularity/code/g.py
- singularity/code/graphics/widget.py
- singularity/code/polib.py
- singularity/code/pycompat.py

Fixes:
- Should read `contains` rather than `contans`.
- Should read `compatibility` rather than `compatiability`.
- Should read `instantiated` rather than `instanciated`.
- Should read `separating` rather than `seperating`.
- Should read `tuple` rather than `touple`.
- Should read `propagated` rather than `propogated`.
- Should read `prerequisites` rather than `preequisites`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md