### PR TITLE
docs: fix simple typo, abence -> absence

### DIFF
--- a/docs/devel/data_files.rst
+++ b/docs/devel/data_files.rst
@@ -184,7 +184,7 @@ should be converted by the ``int`` function before passing it to the
 constructor.
 
 On the other hand, the ``force_cpu`` field is optional and in its
-abence, the constructor receives a ``None``.  Finally, ``danger`` is
+absence, the constructor receives a ``None``.  Finally, ``danger`` is
 optional (defaulting to ``0``).  However, if the ``danger`` field is
 present, the value will be converted by ``int`` (like with ``size``).
 


### PR DESCRIPTION
There is a small typo in docs/devel/data_files.rst.

Should read `absence` rather than `abence`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md