### PR TITLE
fix: wrap pygame.mixer.music calls with exception handling

### DIFF
--- a/singularity/code/mixer.py
+++ b/singularity/code/mixer.py
@@ -216,9 +216,14 @@ def play_music(musicdir=None):
         delay_time = pygame.time.get_ticks() + int(random.random() * 10000) + 2000
         return
 
-    pygame.mixer.music.stop()
-    pygame.mixer.music.load(random.choice(music_dict[musicdir]))
-    pygame.mixer.music.play()
+    try:
+        pygame.mixer.music.stop()
+        pygame.mixer.music.load(random.choice(music_dict[musicdir]))
+        pygame.mixer.music.play()
+    except Exception as reason:
+        sys.stderr.write("Music playback failed; disabling mixer. (%s)\n" % reason)
+        init = False
+        return
     delay_time = 1  # set a (dummy) delay
 
 


### PR DESCRIPTION
## Summary

On pygame versions before 2.5.2, `pygame.mixer.get_init()` can return truthy while the music submodule is not fully initialized. This causes "Audio device hasn't been opened" errors and segfaults when `pygame.mixer.music.load()` or `play()` are called.

## Fix

Wraps the three music calls (`stop()`, `load()`, `play()`) in `play_music()` with exception handling. On failure, writes to stderr and sets `init = False` to prevent retry loops that lead to crashes. This mirrors the error-handling pattern already used in `reinit()`.

## Test results

All 30 existing tests pass (30 passed, 1 XPASS, 2 deprecation warnings unrelated to this change).

## References

- Fixes: https://github.com/singularity/singularity/issues/350

🤖 Generated with [Claude Code](https://claude.com/claude-code)