### PR TITLE
feat: add Ctrl+S quicksave hotkey

### DIFF
--- a/neo_work/WORK_ITEMS.md
+++ b/neo_work/WORK_ITEMS.md
@@ -1,0 +1,18 @@
+# Neo Work Items — Singularity Fork
+
+## Active
+- [ ] **#285** Ctrl-S quicksave hotkey — extend HotKeyMatcher to support CTRL modifier
+
+## In Progress
+
+## Done
+- [x] **#350** pygame.mixer crash — wrapped music calls in try/except (PR #363)
+
+## Backlog
+- [ ] **#343** safety.py crash — log_error causes segfault via Python logging during pygame parachute state
+- [ ] **#331** auto-save improvement
+- [ ] **#337** credits/attribution update
+- [ ] **#319** more music
+- [ ] **#285** Ctrl-S hotkey (blocked by modifier limitation)
+- [ ] **#326** Wayland/Sway crash
+- [ ] **#340** AppImage build

--- a/neo_work/WORK_ITEMS.md
+++ b/neo_work/WORK_ITEMS.md
@@ -1,18 +1,17 @@
 # Neo Work Items — Singularity Fork
 
 ## Active
-- [ ] **#285** Ctrl-S quicksave hotkey — extend HotKeyMatcher to support CTRL modifier
-
-## In Progress
+- [ ] **#343** safety.py crash — log_error causes segfault via Python logging during pygame parachute state
 
 ## Done
 - [x] **#350** pygame.mixer crash — wrapped music calls in try/except (PR #363)
+- [x] **#285** Ctrl-S quicksave hotkey — extended HotKeyMatcher KMOD_CTRL support + test (PR #364)
 
 ## Backlog
-- [ ] **#343** safety.py crash — log_error causes segfault via Python logging during pygame parachute state
 - [ ] **#331** auto-save improvement
 - [ ] **#337** credits/attribution update
 - [ ] **#319** more music
-- [ ] **#285** Ctrl-S hotkey (blocked by modifier limitation)
-- [ ] **#326** Wayland/Sway crash
+- [ ] **#326** Wayland/Sway crash (needs reproduction environment)
 - [ ] **#340** AppImage build
+- [ ] **#349** Slight immersive story details
+- [ ] **#321** diesel generators work on sea floor and moon

--- a/singularity/code/global_hotkeys.py
+++ b/singularity/code/global_hotkeys.py
@@ -45,11 +45,10 @@ class HotKeyMatcher:
         self._hotkeys.clear()
 
     def add_hotkey(self, key: int, hotkey_modifiers: int, action: HotkeyAction) -> None:
-        if hotkey_modifiers not in (0, pygame.KMOD_ALT):
-            # Limitation in implementation, feel free to fix to code to support other modifiers. Will require
-            # a data structure change (ALT + ENTER vs. CTRL + ENTER vs. CTRL + ALT + ENTER) and an up todate to
-            # detect_hotkey
-            raise ValueError("Only ALT is supported as a global hotkey modifier")
+        if hotkey_modifiers not in (0, pygame.KMOD_ALT, pygame.KMOD_CTRL):
+            # Limitation in implementation: supports 0 (function keys), ALT, and CTRL modifiers.
+            # Adding more requires extending the modifier detection in detect_hotkey.
+            raise ValueError("Only ALT and CTRL are supported as global hotkey modifiers")
         if hotkey_modifiers == 0 ^ key in _MODIFIERLESS_HOT_KEYS:
             name = pygame.key.name(key)
             if hotkey_modifiers == 0:
@@ -83,6 +82,7 @@ def reset_hotkeys():
     # FIXME: Make these configurable
     add_hotkey(pygame.K_RETURN, hka.toggle_fullscreen, hotkey_modifiers=pygame.KMOD_ALT)
     add_hotkey(pygame.K_F5, hka.quicksave)
+    add_hotkey(pygame.K_s, hka.quicksave, hotkey_modifiers=pygame.KMOD_CTRL)
     add_hotkey(pygame.K_F6, hka.reload_theme)
     add_hotkey(pygame.K_F9, hka.quickload)
     add_hotkey(pygame.K_F11, hka.toggle_cheat_menu)

--- a/tests/test_hotkeys.py
+++ b/tests/test_hotkeys.py
@@ -25,3 +25,32 @@ def test_hotkeys(input_text, hotkey_chars, cleaned_text):
     assert actual_hotkey_chars == hotkey_chars
     assert actual_cleaned_text == cleaned_text
     assert actual_hotkey_char == expected_hotkey
+
+
+def test_hotkey_matcher_ctrl_modifier():
+    """Test that HotKeyMatcher correctly handles CTRL modifier."""
+    import pygame
+    from singularity.code.global_hotkeys import HotKeyMatcher
+
+    matcher = HotKeyMatcher()
+
+    def dummy_action():
+        pass
+
+    # Ctrl+S should be addable
+    matcher.add_hotkey(pygame.K_s, pygame.KMOD_CTRL, dummy_action)
+    assert pygame.K_s in matcher._hotkeys
+
+    # Plain 's' without modifier should NOT return the hotkey action
+    class MockEvent:
+        type = pygame.KEYDOWN
+        key = pygame.K_s
+
+    pygame.key.get_mods = lambda: 0
+    result = matcher.detect_hotkey(MockEvent())
+    assert result is None
+
+    # Ctrl+S should return the hotkey action (game loop invokes it, not detect_hotkey)
+    pygame.key.get_mods = lambda: pygame.KMOD_CTRL
+    result = matcher.detect_hotkey(MockEvent())
+    assert result is dummy_action


### PR DESCRIPTION
## Summary

Adds Ctrl+S as a quicksave hotkey, complementing the existing F5 binding. This addresses issue #285 where users doing reproducibility testing needed to create many savegames and found the existing "m s tab o y" mouse/keyboard sequence cumbersome.

## Changes

### `singularity/code/global_hotkeys.py`
- Extends `HotKeyMatcher.add_hotkey()` to accept `pygame.KMOD_CTRL` as a valid modifier (previously only `0` and `pygame.KMOD_ALT` were accepted)
- Adds `add_hotkey(pygame.K_s, hka.quicksave, hotkey_modifiers=pygame.KMOD_CTRL)` to `reset_hotkeys()`
- Updates error message and internal comment to reflect the expanded modifier support

### `tests/test_hotkeys.py`
- Adds `test_hotkey_matcher_ctrl_modifier()`: verifies that Ctrl+S is recognized as a hotkey while plain S without modifier is not

## Test results

All 31 tests pass (30 original + 1 new).

## References

- Closes: https://github.com/singularity/singularity/issues/285

🤖 Generated with [Claude Code](https://claude.com/claude-code)